### PR TITLE
Draw enhancements

### DIFF
--- a/QWC2Components/actions/task.js
+++ b/QWC2Components/actions/task.js
@@ -14,7 +14,6 @@ const {changeMapInfoState} = require('../../MapStore2/web/client/actions/mapInfo
 function setCurrentTask(task, mode=null, allowIdentify=false) {
     return (dispatch) => {
         dispatch(changeMeasurement({geomType: null}));
-        dispatch(changeDrawingStatus(null));
         dispatch(changeMapInfoState(task === null || allowIdentify));
         dispatch({
             type: SET_CURRENT_TASK,

--- a/QWC2Components/plugins/Draw.jsx
+++ b/QWC2Components/plugins/Draw.jsx
@@ -10,6 +10,7 @@ const React = require('react');
 const {connect} = require('react-redux');
 const assign = require('object-assign');
 const MessageBar = require('../components/MessageBar');
+const Message = require('../../MapStore2/web/client/components/I18N/Message');
 const {changeDrawingStatus, endDrawing, setCurrentStyle} = require('../../MapStore2/web/client/actions/draw');
 const {setCurrentTask} = require('../actions/task');
 const { SketchPicker } = require('react-color');
@@ -124,15 +125,29 @@ const Draw = React.createClass({
         <MessageBar name="Draw" onClose={this.onClose}>
           <div role="body">
             <div className="buttonbar">
-              <span onClick={()=>this.setDrawMethod('Point')} className={this.statusForDrawMethod('Point')}>Point</span>
-              <span onClick={()=>this.setDrawMethod('LineString')} className={this.statusForDrawMethod('LineString')}>Line</span>
-              <span onClick={()=>this.setDrawMethod('Polygon')} className={this.statusForDrawMethod('Polygon')}>Polygon</span>
+              <span onClick={()=>this.setDrawMethod('Point')} className={this.statusForDrawMethod('Point')}>
+                <Message msgId="draw.point" />
+              </span>
+              <span onClick={()=>this.setDrawMethod('LineString')} className={this.statusForDrawMethod('LineString')}>
+                <Message msgId="draw.line" />
+              </span>
+              <span onClick={()=>this.setDrawMethod('Polygon')} className={this.statusForDrawMethod('Polygon')}>
+                <Message msgId="draw.polygon" />
+              </span>
               <span onClick={()=>this.setDrawMethod('BBOX')} className={this.statusForDrawMethod('BBOX')}>BBOX</span>
-              <span onClick={()=>this.setDrawMethod('Circle')} className={this.statusForDrawMethod('Circle')}>Circle</span>
+              <span onClick={()=>this.setDrawMethod('Circle')} className={this.statusForDrawMethod('Circle')}>
+                <Message msgId="draw.circle" />
+              </span>
 
               <div className="draw-options">
-                <button className="btn btn-danger" onClick={this.deleteSelectedFeatures} disabled={this.hasSelectedFeatures() ? '' : 'disabled'}>Delete</button>
-                <button className="btn btn-default" onClick={this.deleteAllFeatures} disabled={this.props.features.length ? '' : 'disabled'}>Clear all</button>
+                <button className="btn btn-danger" onClick={this.deleteSelectedFeatures}
+                  disabled={this.hasSelectedFeatures() ? '' : 'disabled'}>
+                    <Message msgId="draw.delete" />
+                </button>
+                <button className="btn btn-default" onClick={this.deleteAllFeatures}
+                  disabled={this.props.features.length ? '' : 'disabled'}>
+                  <Message msgId="draw.clearAll" />
+                </button>
               </div>
             </div>
 

--- a/QWC2Components/plugins/Draw.jsx
+++ b/QWC2Components/plugins/Draw.jsx
@@ -47,9 +47,24 @@ const Draw = React.createClass({
   },
 
   componentWillReceiveProps(newProps) {
+    //draw dialog is closed and is activated because user clicks on previously drawn feature
+    if (this.props.drawStatus == null && newProps.drawStatus === 'select') {
+      this.props.setCurrentTask('Draw');
+      this.setState({ drawDialogOpen: true });
+    }
+
+    //recreate draw dialog with previously drawn features
+    if (newProps.drawStatus === 'create') {
+      this.setState({ drawDialogOpen: true });
+
+      if(this.props.features.length > newProps.features.length) {
+        this.props.changeDrawingStatus('replace', null, newProps.drawOwner, this.props.features);
+      }
+    }
+
     newProps.features.forEach(f => {
       //set current style from selected feature
-      if (f.selected && Object.keys(f.style).length > 0) {
+      if (f.selected && Object.keys(f.style).length > 0 && newProps.drawStatus != null) {
         this.props.setCurrentStyle(f.style);
       }
 
@@ -62,8 +77,16 @@ const Draw = React.createClass({
 
   onClose() {
     this.props.setCurrentTask(null);
-    this.props.changeDrawingStatus('clean', null, this.props.drawOwner, this.props.features);
-    this.props.changeDrawingStatus(null, null, null, this.props.features);
+
+    let unselectedFeatures = []
+    this.props.features.forEach(function(f) {
+      f.selected = false;
+      unselectedFeatures.push(f);
+    });
+
+    this.props.changeDrawingStatus(null, null, this.props.drawOwner, unselectedFeatures);
+
+    this.setState({ drawDialogOpen: false });
   },
 
   setDrawMethod(method) {
@@ -116,7 +139,7 @@ const Draw = React.createClass({
   },
 
   render() {
-    if(!this.props.drawStatus) {
+    if(!this.state || (this.state && !this.state.drawDialogOpen)) {
       return null;
     }
 

--- a/QWC2Components/plugins/Draw.jsx
+++ b/QWC2Components/plugins/Draw.jsx
@@ -62,8 +62,8 @@ const Draw = React.createClass({
 
   onClose() {
     this.props.setCurrentTask(null);
-    this.props.changeDrawingStatus('clean', null, this.props.drawOwner, []);
-    this.props.changeDrawingStatus(null, null, null, []);
+    this.props.changeDrawingStatus('clean', null, this.props.drawOwner, this.props.features);
+    this.props.changeDrawingStatus(null, null, null, this.props.features);
   },
 
   setDrawMethod(method) {

--- a/QWC2Components/plugins/Draw.jsx
+++ b/QWC2Components/plugins/Draw.jsx
@@ -13,7 +13,7 @@ const MessageBar = require('../components/MessageBar');
 const Message = require('../../MapStore2/web/client/components/I18N/Message');
 const {changeDrawingStatus, endDrawing, setCurrentStyle} = require('../../MapStore2/web/client/actions/draw');
 const {setCurrentTask} = require('../actions/task');
-const { SketchPicker } = require('react-color');
+const { TwitterPicker } = require('react-color');
 
 require('./style/Draw.css');
 
@@ -155,11 +155,11 @@ const Draw = React.createClass({
               <div className="style-row">
                 <span className="style-rule">
                   <label>Stroke color</label>
-                  <input type="text" value={this.props.currentStyle.strokeColor}
+                  <input type="text" style={{backgroundColor: this.props.currentStyle.strokeColor}}
                     onChange={(evt) => this.updateStyleRule('strokeColor', evt.target.value)}
                     onFocus={() => this.setState({ displayStrokeColorPicker: true })} />
                   <span className={this.state && this.state.displayStrokeColorPicker ? "color-picker" : "collapse" }>
-                    <SketchPicker color={this.props.currentStyle.StrokeColor} onChangeComplete={(color) => this.updateStyleRule('strokeColor', color.hex)} />
+                    <TwitterPicker color={this.props.currentStyle.StrokeColor} onChangeComplete={(color) => this.updateStyleRule('strokeColor', color.hex)} />
                   </span>
                 </span>
 
@@ -172,12 +172,12 @@ const Draw = React.createClass({
               <div className="style-row">
                 <span className="style-rule">
                   <label>Fill color</label>
-                  <input type="text" value={this.props.currentStyle.fillColor}
+                  <input type="text"  style={{backgroundColor: this.props.currentStyle.fillColor}}
                       onChange={(evt) => this.updateStyleRule('fillColor', evt.target.value)}
                       onFocus={() => this.setState({ displayFillColorPicker: true })} />
 
                   <span className={this.state && this.state.displayFillColorPicker ? "color-picker" : "collapse" }>
-                    <SketchPicker color={this.props.currentStyle.fillColor} onChangeComplete={(color) => this.updateStyleRule('fillColor', color.hex)} />
+                    <TwitterPicker color={this.props.currentStyle.fillColor} onChangeComplete={(color) => this.updateStyleRule('fillColor', color.hex)} />
                   </span>
                 </span>
 

--- a/QWC2Components/plugins/Draw.jsx
+++ b/QWC2Components/plugins/Draw.jsx
@@ -181,10 +181,11 @@ const Draw = React.createClass({
                   </span>
                 </span>
 
-                <span className="style-rule">
+                <span className="style-rule fill-opacity">
                   <label>Fill opacity</label>
-                  <input type="text" value={this.props.currentStyle.fillTransparency}
+                  <input type="range" min="0" max="1" step="0.1" value={this.props.currentStyle.fillTransparency}
                     onChange={(evt) => this.updateStyleRule('fillTransparency', evt.target.value)} />
+                  <span>{this.props.currentStyle.fillTransparency*100}%</span>
                 </span>
               </div>
               <div className="style-row">

--- a/QWC2Components/plugins/style/Draw.css
+++ b/QWC2Components/plugins/style/Draw.css
@@ -22,6 +22,15 @@
   margin-right: 10px;
 }
 
+.draw-style .style-rule.fill-opacity span {
+  position: absolute;
+  right: -40px;
+}
+
+.draw-style .style-rule.fill-opacity input[type='range'] {
+  width: 100px !important;
+}
+
 .draw-style .style-rule .color-picker {
   position: absolute;
   top: 35px;

--- a/translations/data.en-US
+++ b/translations/data.en-US
@@ -96,6 +96,14 @@
     },
     "themeswitcher": {
       "filter": "Filter..."
+    },
+    "draw": {
+      "delete": "Delete",
+      "clearAll": "Clear all",
+      "point": "Point",
+      "line": "Line",
+      "polygon": "Polygon",
+      "circle": "Circle"
     }
   }
 }

--- a/translations/data.sv-SE
+++ b/translations/data.sv-SE
@@ -1,0 +1,109 @@
+{
+  "locale": "sv-SE",
+  "messages": {
+    "appmenu": {
+      "items": {
+        "Draw": "Rita",
+        "DxfExport": "DXF Export",
+        "Help": "Hjälp",
+        "LayerTree": "Lager & teckenförklaring",
+        "Measure": "Mät",
+        "Print": "Skriv ut",
+        "RasterExport": "Raster Export",
+        "Share": "Dela länk",
+        "ThemeSwitcher": "Tema",
+        "Tools": "Kartverktyg",
+        "IdentifyRegion": ""
+      },
+      "menulabel": "Karta & Verktyg"
+    },
+    "bgswitcher": {
+      "nobg": "Ingen backgrund"
+    },
+    "bottombar": {
+      "mousepos_label": "Koordinater",
+      "scale_label": "Skala",
+      "terms_label": "Villkor",
+      "viewertitle_label": "QWC2 Demo"
+    },
+    "dxfexport": {
+      "selectinfo": "Rita en rektangel runt området som ska exporteras...",
+      "symbologyscale": "Symbolskala:"
+    },
+    "identifyTitle": "Information",
+    "identify": {
+      "querying": "Frågar..."
+    },
+    "identifyregion": {
+      "info": ""
+    },
+    "layerinfo": {
+      "title": "",
+      "abstract": "",
+      "attribution": "",
+      "keywords": "",
+      "dataUrl": "",
+      "metadataUrl": "",
+      "legend": ""
+    },
+    "layertree": {
+      "maptip": "Visa karttips för lager",
+      "transparency": "Transparens",
+      "printlegend": ""
+    },
+    "locate": {
+      "tooltip": "",
+      "metersUnit": "",
+      "feetUnit": "",
+      "popup": "",
+      "outsideMapBoundsMsg": ""
+    },
+    "map": {
+      "loading": "Laddar..."
+    },
+    "measureComponent": {
+      "areaLabel": "Area",
+      "bearingLabel": "Bäring",
+      "lengthLabel": "Längd",
+      "pointLabel": "Position"
+    },
+    "noFeatureInfo": "Det finns ingen information där du klickade",
+    "print": {
+      "layout": "Layout:",
+      "nolayouts": "Valt tema stöder inte utskrift",
+      "notheme": "Inget tema valt",
+      "resolution": "Upplösning:",
+      "rotation": "Rotation:",
+      "scale": "Skala:",
+      "submit": "Skriv ut"
+    },
+    "rasterexport": {
+      "format": "",
+      "selectinfo": ""
+    },
+    "search": {
+      "coordinates": "Koordinater",
+      "placeholder": "Sök efter platser och koordinater...",
+      "more": ""
+    },
+    "share": {
+      "directLinkTitle": "Via en direktlänk",
+      "generatingpermalink": "Genererar permalink...",
+      "msgToCopyUrl": "Klicka för att kopiera",
+      "msgCopiedUrl": "",
+      "QRCodeLinkTitle": "qr kod",
+      "socialIntro": "I ditt favoritnätverk"
+    },
+    "themeswitcher": {
+      "filter": "Filtrera..."
+    },
+    "draw": {
+      "delete": "Ta bort",
+      "clearAll": "Ta bort alla",
+      "point": "Punkt",
+      "line": "Linje",
+      "polygon": "Polygon",
+      "circle": "Cirkel"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds some tweaks to the Draw component. 

Before this can be merged one issue should be solved - when user closes draw dialog(and features remain on the map) and the clicks on the drawn feature, the dialog gets opened, but then Identify tool remains enabled. I couldn't figure out how to disable it for this scenario, so any suggestions appreciated.