### PR TITLE
Fix GetFeatureInfo in duplicate projects

### DIFF
--- a/scripts/themesConfig.js
+++ b/scripts/themesConfig.js
@@ -290,7 +290,7 @@ function getTheme(configItem, resultItem) {
 
             // update theme config
             resultItem.id = themeId;
-            resultItem.name = themeId;
+            resultItem.name = topLayer.Name;
             resultItem.title = wmsTitle;
             resultItem.attribution = configItem.attribution;
             resultItem.attributionUrl = configItem.attributionUrl;

--- a/scripts/themesConfig.py
+++ b/scripts/themesConfig.py
@@ -259,7 +259,7 @@ def getTheme(configItem, resultItem):
 
         # update theme config
         resultItem["id"] = themeId
-        resultItem["name"] = themeId
+        resultItem["name"] = getChildElementValue(topLayer, "Name")
         resultItem["title"] = wmsTitle
         resultItem["attribution"] = configItem["attribution"]
         resultItem["attributionUrl"] = configItem["attributionUrl"]


### PR DESCRIPTION
Hello,

If the same project is used (multiple themes pointing to it),
the old behavior added an id to the name of the layer which resulted
in GetFeatureInfo requests being sent to a false layer name consisting
of real_lyrname + id (0 in my case).