### PR TITLE
get default theme by ID

### DIFF
--- a/scripts/themesConfig.js
+++ b/scripts/themesConfig.js
@@ -342,7 +342,7 @@ function getTheme(configItem, resultItem) {
 
             // set default theme
             if (configItem.default || !result.themes.defaultTheme) {
-                result.themes.defaultTheme = resultItem.name;
+                result.themes.defaultTheme = resultItem.id;
             }
 
             // get thumbnail asynchronously

--- a/scripts/themesConfig.py
+++ b/scripts/themesConfig.py
@@ -319,7 +319,7 @@ def getTheme(configItem, resultItem):
 
         # set default theme
         if "default" in configItem or not result["themes"]["defaultTheme"]:
-            result["themes"]["defaultTheme"] = resultItem["name"]
+            result["themes"]["defaultTheme"] = resultItem["id"]
 
         # use first CRS for thumbnail request which is not CRS:84
         for item in topLayer.getElementsByTagName("CRS"):


### PR DESCRIPTION
Before
https://github.com/qgis/qwc2/commit/f7559eb720e4f68c62ecb66af31153580f2c3e50
the themeId was the same as themeName and it all worked fine.

This fixes the Default theme for the case where themes have the same
root.