### PR TITLE
themesconfig.js and package-commands.sh writes bad config

### DIFF
--- a/scripts/package-commands.sh
+++ b/scripts/package-commands.sh
@@ -19,7 +19,7 @@ if [ "$1" == "prod" ]; then
     && cp -a ./dist ./index.html ./assets ./themes.json ./prod \
     && cp -a  $config ./prod/config.json \
     && cp -a ./translations/data.* ./prod/translations
-    exit 0
+    exit $?
 fi
 if [ "$1" == "analyze" ]; then
     NODE_ENV='production' webpack --json | webpack-bundle-size-analyzer

--- a/scripts/themesConfig.js
+++ b/scripts/themesConfig.js
@@ -182,7 +182,7 @@ function getTheme(configItem, resultItem) {
     parsedUrl.query.REQUEST = "GetProjectSettings";
     const getCapabilitiesUrl = urlUtil.format(parsedUrl);
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
         axios.get(getCapabilitiesUrl).then((response) => {
             // parse capabilities
             var capabilities;
@@ -352,7 +352,7 @@ function getTheme(configItem, resultItem) {
             resultItem.error = "Could not read GetProjectSettings";
             resultItem.title = "Error";
             // finish task
-            resolve(false);
+            reject(resultItem.error);
         });
     });
 }
@@ -497,10 +497,12 @@ Promise.all(tasks).then(() => {
     fs.writeFile(process.cwd() + '/themes.json', JSON.stringify(result, null, 2), (error) => {
         if (error) {
             console.error("ERROR:", error);
+            process.exit(1);
         } else {
             console.log("\nCreated themes.json\n\n");
         }
     });
 }).catch((error) => {
     console.error("ERROR:", error);
+    process.exit(1);
 });


### PR DESCRIPTION
The exit code of **package-commands.sh** is always 0 (success). **themesconfig.js** detects a bad **themesConfig.json** and outputs error but **themes.json** is still overwritten and the exit code is 0 (success).

¤ A good **themes.json** must not be overwritten with a bad **themes.json**.
¤ **themesconfig.js** should always fail if **themesConfig.json** contains errors.
¤ Scripts should always return correct exit code.