### PR TITLE
Fix the possibility of users setting rotation to Blank

### DIFF
--- a/QWC2Components/plugins/Print.jsx
+++ b/QWC2Components/plugins/Print.jsx
@@ -259,7 +259,7 @@ const Print = React.createClass({
         this.setState({dpi: ev.target.value});
     },
     changeRotation(ev) {
-        let angle = parseFloat(ev.target.value);
+        let angle = parseFloat(ev.target.value) || 0;
         while(angle < 0) {
             angle += 360;
         }


### PR DESCRIPTION
It is currently possible to delete the rotation angle, thus
setting the angle to NaN value. which in turn outputs a blank map.
This fixes it.