### PR TITLE
untoggle feature if the parent layer is colapsed/untoggled

### DIFF
--- a/QWC2Components/components/IdentifyViewer.jsx
+++ b/QWC2Components/components/IdentifyViewer.jsx
@@ -148,7 +148,12 @@ const IdentifyViewer = React.createClass({
         let newstate = this.state.expanded[path] !== undefined ? !this.state.expanded[path] : !deflt;
         let diff = {};
         diff[path] = newstate;
-        this.setState(assign({}, this.state, {expanded: assign({}, this.state.expanded, diff)}));
+        if (this.state.currentLayer == path && !newstate){
+            this.setState(assign({}, this.state, {expanded: assign({}, this.state.expanded, diff), currentFeature: null, currentLayer: null}));
+        }
+        else{
+            this.setState(assign({}, this.state, {expanded: assign({}, this.state.expanded, diff)}));
+        }
     },
     setCurrentFeature(layer, feature) {
         if(this.state.currentFeature === feature) {


### PR DESCRIPTION
If you select a feature and you collapse the parent layer the feature
remains selected. The normal behavior in my mind is that feature should
be deselected if the user untoggles the parent layer.

What do you think?