### PR TITLE
fix z-index of resizable-window

### DIFF
--- a/QWC2Components/components/style/ResizeableWindow.css
+++ b/QWC2Components/components/style/ResizeableWindow.css
@@ -2,6 +2,7 @@ div.resizeable-window {
     background-color: @dialog_bg@;
     color: @dialog_fg@;
     box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.75);
+    z-index: 9;
 }
 
 div.resizeable-window-titlebar {


### PR DESCRIPTION
before this, the info window could be moved under the top bar, nulling the possibility of easy closing.
![before](https://user-images.githubusercontent.com/11608132/30474646-0c1787f6-9a0d-11e7-95c4-5dbe1cf1ba57.png)

after
![after](https://user-images.githubusercontent.com/11608132/30474654-12223bf0-9a0d-11e7-9fff-170ed43c7d3e.png)

