### PR TITLE
set parent bounds for resizable window

### DIFF
--- a/QWC2Components/components/ResizeableWindow.jsx
+++ b/QWC2Components/components/ResizeableWindow.jsx
@@ -63,7 +63,7 @@ const ResizeableWindow = React.createClass({
             icon = (<img src={this.props.icon} />);
         }
         return (
-            <Rnd className="resizeable-window" default={initial}
+            <Rnd className="resizeable-window" bounds="parent" default={initial}
                 minWidth={this.props.minWidth} minHeight={this.props.minHeight}
                 maxWidth={this.props.maxWidth || window.innerWidth} maxHeight={this.props.maxHeight || window.innerHeight}>
                 <div className="resizeable-window-titlebar">


### PR DESCRIPTION
fix - if the user drag the identify window up outside the map window, there is no possibility to drag it back or close

![screenshot from 2017-11-23 12-53-09](https://user-images.githubusercontent.com/11608132/33169784-8ee7c52a-d04e-11e7-8af5-a5f268b77aa4.png)
