### PR TITLE
fix typo in DxfExport

### DIFF
--- a/QWC2Components/plugins/DxfExport.jsx
+++ b/QWC2Components/plugins/DxfExport.jsx
@@ -43,7 +43,7 @@ class DxfExport extends React.Component {
                 <input type="hidden" name="FORMAT" value="application/dxf" readOnly="true" />
                 <input type="hidden" name="LAYERS" value={themeSubLayers} readOnly="true" />
                 <input type="hidden" name="CRS" value={this.props.map.projection} readOnly="true" />
-                <input type="hidden" name="FILENAME" value={this.props.theme.name + ".dxf"} readOnly="true" />
+                <input type="hidden" name="FILE_NAME" value={this.props.theme.name + ".dxf"} readOnly="true" />
                 <input ref={input => this.extentInput = input} type="hidden" name="BBOX" value="" readOnly="true" />
                 </form>
             </span>


### PR DESCRIPTION
parameter FILENAME should be FILE_NAME (see https://docs.qgis.org/2.18/en/docs/user_manual/working_with_ogc/ogc_server_support.html#dxf-export)