### PR TITLE
remove html tags fom search text for marker label

### DIFF
--- a/QWC2Components/components/Search.jsx
+++ b/QWC2Components/components/Search.jsx
@@ -360,6 +360,7 @@ class Search extends React.Component {
         if((item.type || SearchResultType.PLACE) === SearchResultType.PLACE) {
             this.props.removeLayer("searchselection");
             let text = item.label !== undefined ? item.label : item.text;
+            text = text.replace(/<[^>]*>/g, '')
             if(item.provider && this.props.searchProviders[item.provider].getResultGeometry) {
                 this.props.searchProviders[item.provider].getResultGeometry(item, (item, geometry, crs) => { this.showFeatureGeometry(item, geometry, crs, text)});
             }


### PR DESCRIPTION
for example http://api3.geo.admin.ch/rest/services/api/SearchServer returns label with html tags and the ol.style.text display it like string