### PR TITLE
Redundant offset while clicking positioned map fixed

### DIFF
--- a/MapStore2Components/components/map/openlayers/Map.jsx
+++ b/MapStore2Components/components/map/openlayers/Map.jsx
@@ -96,8 +96,8 @@ class OpenlayersMap extends React.Component {
                 return;
             }
             this.props.onClick({
-                coordinate: this.map.getCoordinateFromPixel([event.clientX, event.clientY]),
-                pixel: [event.clientX, event.clientY],
+                coordinate: this.map.getEventCoordinate(event),
+                pixel: this.map.getEventPixel(event),
                 modifiers: {
                     alt: event.altKey,
                     ctrl: event.ctrlKey,
@@ -109,8 +109,8 @@ class OpenlayersMap extends React.Component {
         map.getViewport().addEventListener('contextmenu', (event)  => {
             event.preventDefault();
             this.props.onClick({
-                coordinate: this.map.getCoordinateFromPixel([event.clientX, event.clientY]),
-                pixel: [event.clientX, event.clientY],
+                coordinate: this.map.getEventCoordinate(event),
+                pixel: this.map.getEventPixel(event),
                 modifiers: {
                     alt: event.altKey,
                     ctrl: event.ctrlKey,


### PR DESCRIPTION
If map container is positioned via "top","left","margin","padding" etc. maptiptool opens in a wrong place and identifytool identifies wrong coordinates. 

I've solved this problem.