### PR TITLE
prevent not visible highlight-layers from being printed

### DIFF
--- a/QWC2Components/utils/VectorLayerUtils.js
+++ b/QWC2Components/utils/VectorLayerUtils.js
@@ -30,7 +30,7 @@ const VectorLayerUtils = {
         const ensureHex = (rgb) => (!Array.isArray(rgb) ? rgb : ('#' + (0x1000000 + (rgb[2] | (rgb[1] << 8) | (rgb[0] << 16))).toString(16).slice(1)));
 
         for(let layer of layers.slice(0).reverse()) {
-            if(layer.type != 'vector' || (layer.features || []).length == 0) {
+            if(layer.type != 'vector' || (layer.features || []).length == 0 || layer.visibility === false) {
                 continue;
             }
             for(let feature of layer.features) {


### PR DESCRIPTION
currently highlight-layers are always printed (getPrint).