### PR TITLE
Allow to pass http basic credentials during configuration

### DIFF
--- a/scripts/themesConfig.js
+++ b/scripts/themesConfig.js
@@ -87,7 +87,10 @@ function getThumbnail(configItem, resultItem, layers, crs, extent, resolve) {
     parsedUrl.query.LAYERS = layers.join(',');
     const getMapUrl = urlUtil.format(parsedUrl);
 
-    axios.get(getMapUrl, {responseType: "arraybuffer"}).then((response) => {
+    axios.get(getMapUrl, {
+        responseType: "arraybuffer",
+        auth: configItem.wmsBasicAuth,
+    }).then((response) => {
         let basename = configItem.url.replace(/.*\//, "").replace(/\?.*$/, "") + ".png";
         try {
             fs.mkdirSync("./assets/img/genmapthumbs/");
@@ -222,7 +225,7 @@ function getTheme(config, configItem, result, resultItem) {
     const getCapabilitiesUrl = urlUtil.format(parsedUrl);
 
     return new Promise((resolve, reject) => {
-        axios.get(getCapabilitiesUrl).then((response) => {
+        axios.get(getCapabilitiesUrl, { auth: configItem.wmsBasicAuth, }).then((response) => {
             // parse capabilities
             let capabilities;
             xml2js.parseString(response.data, {


### PR DESCRIPTION
This is very useful when building the sites on dev machine or using an external maps service.

Note that the latter use case is still not completely supported by qwc2, because some runtime requests like getFeatureInfo needs proper CORS configuration if the front has a different Origin than the map server.

Supporting the latter will require being able to configure axios on a per-host basis.

This implements my request on [qwc2-example-app repo](https://github.com/qgis/qwc2-demo-app/issues/141).