### PR TITLE
override img vertical-align for icons

### DIFF
--- a/components/style/Icon.css
+++ b/components/style/Icon.css
@@ -2,6 +2,10 @@
     display: inline-block;
 }
 
+img.icon {
+    vertical-align: top;
+}
+
 span.iconlarge:before {
     font-size: large;
 }


### PR DESCRIPTION
otherwise img icons in TopBar are not inline:

before:
![topbar](https://user-images.githubusercontent.com/30912074/54569206-3c026980-49da-11e9-917d-1e17f8a37cd0.png)
after:
![topbar2](https://user-images.githubusercontent.com/30912074/54569366-dc588e00-49da-11e9-8e0f-6f69b5534a47.png)


