### PR TITLE
FeatureInfo on external WMS Layers added with ImportLayer

### DIFF
--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -263,7 +263,7 @@ class IdentifyViewer extends React.Component {
             );
         } else if(result.type === "html") {
             resultbox = (
-                <iframe className="identify-result-box" onLoad={ev => this.setIframeContent(ev.target, result.text)}></iframe>
+                <iframe className="identify-result-box" srcDoc={result.text} onLoad={ev => this.setIframeContent(ev.target, result.text)}></iframe>
             );
         } else if(result.properties.htmlContent) {
             if(result.properties.htmlContentInline) {

--- a/utils/ServiceLayerUtils.js
+++ b/utils/ServiceLayerUtils.js
@@ -46,6 +46,10 @@ const ServiceLayerUtils = {
         } catch(e) {
             infoFormats = ['text/plain'];
         }
+        // prefer text/html
+        if(infoFormats.includes('text/html')) {
+            infoFormats = ['text/html'];
+        }
         let topLayer = null;
         let serviceUrl = null;
         try {


### PR DESCRIPTION
FeatureInfo on external WMS Layers added with ImportLayer get executed but the IdentifyViewer says "No information available for the selected point". Problem is that the request is called with info_format=text/xml as WMS servers responding with a different content which is not getting parsed by IdentifyUtils.

So i did a little fix here to prefer "text/html" for ServiceLayerUtils: https://github.com/stephaschu/qwc2/commit/77367800f687db961f94291693022027df4e2516

Also if the request is called with "text/html", chrome does not render the result. The onload event at iframe showing the result is somewhow not not firing, so i added srcDoc: https://github.com/stephaschu/qwc2/commit/a72e681e3a8454d22e0d29e25e5a7a8e7b301142