### PR TITLE
Use history.replaceState rather than pushState

### DIFF
--- a/utils/PermaLinkUtils.js
+++ b/utils/PermaLinkUtils.js
@@ -25,7 +25,7 @@ const UrlParams = {
            }
        }
        delete urlObj.search;
-       history.pushState({id: urlObj.host}, '', url.format(urlObj));
+       history.replaceState({id: urlObj.host}, '', url.format(urlObj));
    },
    getParam: function(key) {
        var urlObj = url.parse(window.location.href, true);


### PR DESCRIPTION
This PR suggests to use history.replaceState rather than history.pushState in PermalinkUtils.js. This is to update the URL in the address bar without actually pushing a new history entry to the history stack.

There is a lot more that could be done using the history API. This PR just fixes the issue reported with https://github.com/qgis/qwc2-demo-app/issues/148.