### PR TITLE
change map on click with singleclick

### DIFF
--- a/components/map/openlayers/Map.jsx
+++ b/components/map/openlayers/Map.jsx
@@ -88,7 +88,7 @@ class OpenlayersMap extends React.Component {
             });
         }
         map.on('moveend', this.updateMapInfoState);
-        map.on('click', (event) => {
+        map.on('singleclick', (event) => {
             let features = [];
             this.map.forEachFeatureAtPixel(event.pixel, (feature, layer) => {
                 features.push([feature, layer]);


### PR DESCRIPTION
I propose to change 
`map.on('click', (event) => {`
 with 
`map.on('singleclick', (event) => {` 
because it is very annoying when the DoubleClickZoom is true especially on mobile