### PR TITLE
wmts reprojection

### DIFF
--- a/components/map/openlayers/plugins/WMTSLayer.js
+++ b/components/map/openlayers/plugins/WMTSLayer.js
@@ -30,6 +30,7 @@ let WMTSLayer = {
             source: new ol.source.WMTS(assign({
               urls: urls,
               layer: options.name,
+              projection: projection && projection.getExtent() ? projection : null,
               matrixSet: options.tileMatrixSet,
               tileGrid: new ol.tilegrid.WMTS({
                 origin: [options.originX, options.originY],


### PR DESCRIPTION
When using a custom projection like epsg:25832 as mapCrs and adding wmts layer in epsg:3857, 
the wmts layer not getting reprojected to epsg:25832. 
As stated here https://openlayers.org/en/latest/doc/tutorials/raster-reprojection.html source needs a projection with an extent for the custom projection to be reprojected.