### PR TITLE
fix layergroup tristate

### DIFF
--- a/plugins/LayerTree.jsx
+++ b/plugins/LayerTree.jsx
@@ -105,7 +105,7 @@ class LayerTree extends React.Component {
     }
     getGroupVisibility = (group) => {
         if(isEmpty(group.sublayers) || group.visibility === false) {
-            return group.visibility;
+            return 0;
         }
         let visible = 0;
         group.sublayers.map(sublayer => {


### PR DESCRIPTION
getGroupVisibility should return a number otherwise groups end up in tristate if unchecked

![1](https://user-images.githubusercontent.com/30912074/64045847-a6fbc300-cb6a-11e9-834e-509ac6130f1f.PNG)
