### PR TITLE
Add missing dependency for RedliningBufferSupport

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "license": "BSD-2-Clause",
     "repository": "git@github.com:qgis/qwc2.git",
     "dependencies": {
+        "@turf/buffer": "5.1.0",
         "axios": "0.19.0",
         "babel-polyfill": "6.26.0",
         "chartist": "0.11.3",


### PR DESCRIPTION
also the icon is missing in https://github.com/qgis/qwc2/tree/master/icons
could you please add it? nice feature btw