### PR TITLE
Allow overwriting of legendUrl, featureInfoUrl and printUrl

### DIFF
--- a/scripts/themesConfig.js
+++ b/scripts/themesConfig.js
@@ -382,9 +382,21 @@ function getTheme(config, configItem, result, resultItem, proxy) {
                 resultItem.print = printTemplates;
             }
             resultItem.drawingOrder = drawingOrder;
-            resultItem.legendUrl = capabilities.Capability.Request.GetLegendGraphic.DCPType.HTTP.Get.OnlineResource.$['xlink:href'] + (configItem.extraLegendParameters ? configItem.extraLegendParameters : '');
-            resultItem.featureInfoUrl = capabilities.Capability.Request.GetFeatureInfo.DCPType.HTTP.Get.OnlineResource.$['xlink:href'];
-            resultItem.printUrl = capabilities.Capability.Request.GetPrint.DCPType.HTTP.Get.OnlineResource.$['xlink:href'];
+            if (configItem.legendUrl) {
+                resultItem.legendUrl = configItem.legendUrl;
+            } else{
+                resultItem.legendUrl = capabilities.Capability.Request.GetLegendGraphic.DCPType.HTTP.Get.OnlineResource.$['xlink:href'] + (configItem.extraLegendParameters ? configItem.extraLegendParameters : '');
+            }
+            if (configItem.featureInfoUrl) {
+                resultItem.featureInfoUrl = configItem.featureInfoUrl;
+            } else{
+                resultItem.featureInfoUrl = capabilities.Capability.Request.GetFeatureInfo.DCPType.HTTP.Get.OnlineResource.$['xlink:href'];
+            }
+            if (configItem.printUrl) {
+                resultItem.printUrl = configItem.printUrl;
+            } else{
+                resultItem.printUrl = capabilities.Capability.Request.GetPrint.DCPType.HTTP.Get.OnlineResource.$['xlink:href'];
+            }
             if(configItem.printLabelForSearchResult) {
                 resultItem.printLabelForSearchResult = configItem.printLabelForSearchResult;
             }

--- a/scripts/themesConfig.py
+++ b/scripts/themesConfig.py
@@ -383,9 +383,18 @@ def getTheme(config, configItem, result, resultItem):
             resultItem["print"] = printTemplates
         resultItem["drawingOrder"] = drawingOrder
         extraLegenParams = configItem["extraLegendParameters"] if "extraLegendParameters" in configItem else ""
-        resultItem["legendUrl"] = getChildElement(capabilities, "Capability/Request/GetLegendGraphic/DCPType/HTTP/Get/OnlineResource").getAttribute("xlink:href") + extraLegenParams
-        resultItem["featureInfoUrl"] = getChildElement(capabilities, "Capability/Request/GetFeatureInfo/DCPType/HTTP/Get/OnlineResource").getAttribute("xlink:href")
-        resultItem["printUrl"] = getChildElement(capabilities, "Capability/Request/GetPrint/DCPType/HTTP/Get/OnlineResource").getAttribute("xlink:href")
+        if "legendUrl" in configItem:
+            resultItem["legendUrl"] = configItem["legendUrl"]
+        else:
+            resultItem["legendUrl"] = getChildElement(capabilities, "Capability/Request/GetLegendGraphic/DCPType/HTTP/Get/OnlineResource").getAttribute("xlink:href") + extraLegenParams
+        if "featureInfoUrl" in configItem:
+            resultItem["featureInfoUrl"] = configItem["featureInfoUrl"]
+        else:
+            resultItem["featureInfoUrl"] = getChildElement(capabilities, "Capability/Request/GetFeatureInfo/DCPType/HTTP/Get/OnlineResource").getAttribute("xlink:href")
+        if "printUrl" in configItem:
+            resultItem["printUrl"] = configItem["printUrl"]
+        else:
+            resultItem["printUrl"] = getChildElement(capabilities, "Capability/Request/GetPrint/DCPType/HTTP/Get/OnlineResource").getAttribute("xlink:href")
         if "printLabelForSearchResult" in configItem:
             resultItem["printLabelForSearchResult"] = configItem["printLabelForSearchResult"]
         if "printLabelConfig" in configItem:


### PR DESCRIPTION
Allows to manually overwrite the values:
- `legendUrl`
- `featureInfoUrl`
- `printUrl`

in the `themesConfig.json` file.

This is useful if you want to use the same QGIS project on different systems, using different `themesConfig.json`files, but without changing the advertised URL in the QGIS project each time.