### PR TITLE
set empty date value to null instead of empty string

### DIFF
--- a/components/AutoEditForm.jsx
+++ b/components/AutoEditForm.jsx
@@ -88,8 +88,7 @@ class AutoEditForm extends(React.Component) {
                 <span className="input-frame">
                     <input name={field.id} type={field.type} {...constraints}
                         onChange={(ev) => {
-                            // set empty date field value to null instead of empty string
-                            this.props.updateField(field.id, ev.target.value == '' ? null : ev.target.value);
+                            this.props.updateField(field.id, ev.target.value);
                         }}
                         value={value}/>
                 </span>

--- a/components/widgets/style/ToggleSwitch.css
+++ b/components/widgets/style/ToggleSwitch.css
@@ -47,3 +47,8 @@ div.ToggleSwitch.toggle-switch-active > span.toggle-switch-no {
 div.ToggleSwitch.toggle-switch-inactive > span.toggle-switch-yes {
     display: none;
 }
+
+
+div.ToggleSwitch > input {
+    display: none;
+}

--- a/plugins/Editing.jsx
+++ b/plugins/Editing.jsx
@@ -246,6 +246,8 @@ class Editing extends React.Component {
             let element = ev.target.elements.namedItem(name);
             if(element) {
                 let value = element.type === "radio" || element.type === "checkbox" ? element.checked : element.value;
+                // set empty date value to null instead of empty string
+                if (element.type === "date" && element.value === "") value = null;
                 if(feature.properties[name] === undefined) {
                     feature.properties[name] = value;
                 }


### PR DESCRIPTION
set empty date value to null instead of empty string even if the field is left untouched not just onChange and avoid 

> Warning: `value` prop on `input` should not be null.

> 