### PR TITLE
Freehand drawing option in Redlining tool

### DIFF
--- a/icons/freehand.svg
+++ b/icons/freehand.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.1-dev (bc69992, 2020-04-15)"
+   height="24"
+   width="24"
+   sodipodi:docname="freehand.svg"
+   id="svg6"
+   version="1.1"
+   viewBox="0 0 24 24">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:snap-bbox="false"
+     inkscape:current-layer="svg6"
+     inkscape:window-maximized="0"
+     inkscape:window-y="23"
+     inkscape:window-x="65"
+     inkscape:cy="11.267148"
+     inkscape:cx="11.277911"
+     inkscape:zoom="29.974231"
+     showgrid="true"
+     id="namedview8"
+     inkscape:window-height="977"
+     inkscape:window-width="1673"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#8b8b8b">
+    <inkscape:grid
+       originy="0"
+       originx="0"
+       id="grid4474"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3051">
+    <style
+       id="current-color-scheme"
+       type="text/css">
+      .ColorScheme-Text {
+        color:#4d4d4d;
+      }
+      </style>
+  </defs>
+  <path
+     id="path817"
+     d="m 0.48657559,8.7946181 c 0,0 6.76218361,2.5141709 3.36709081,5.5729199 -3.39509508,3.058748 3.3670888,5.572918 3.3670888,5.572918"
+     style="fill:none;stroke:#000000;stroke-width:1.39858;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 7.2207552,19.940456 V 14.979547 L 18.796211,3.4040918 23.75712,8.365001 12.181664,19.940456 V 18.28682 L 19.623029,10.845455 16.315756,7.5381827 8.8743912,14.979547 v 2.480454 l 0.826819,0.826819 h 2.4804538 v 1.653636 z"
+     id="path814-4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccccc" />
+  <path
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 11.354846,12.499092 v 2.480455 h 2.480455 v 1.653636 l -0.826819,0.826818 V 15.806365 H 10.528028 V 13.32591 Z"
+     id="path816-0"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccc" />
+</svg>

--- a/plugins/Redlining.jsx
+++ b/plugins/Redlining.jsx
@@ -130,7 +130,7 @@ class Redlining extends React.Component {
                         <div><Message msgId="redlining.draw" /></div>
                         <span>
                             <ButtonBar buttons={drawButtons} active={activeButton} onClick={(key, data) => this.actionChanged(data)} />
-                            {this.props.redlining.geomType === "LineString" || this.props.redlining.geomType === "Polygon" ?
+                            {this.props.redlining.action === "Draw" && (this.props.redlining.geomType === "LineString" || this.props.redlining.geomType === "Polygon") ?
                                 <ButtonBar buttons={freehandButtons} active={activeFreeHand} onClick={(key, data) => this.actionChanged(data)} /> : null
                             }
                         </span>

--- a/plugins/Redlining.jsx
+++ b/plugins/Redlining.jsx
@@ -95,6 +95,12 @@ class Redlining extends React.Component {
             {key: "Polygon", tooltip: "redlining.polygon", icon: "polygon", data: {action: "Draw", geomType: "Polygon", text: ""}},
             {key: "Text", tooltip: "redlining.text", icon: "text", data: {action: "Draw", geomType: "Text", text: ""}},
         ];
+        let activeFreeHand = this.props.redlining.freehand ? "HandDrawing" : null;
+        let freehandButtons = [
+            {key: "HandDrawing", tooltip: "redlining.freehand", icon: "freehand",
+            data: {action: "Draw", geomType: this.props.redlining.geomType, text: "", freehand: !this.props.redlining.freehand},
+            disabled: (this.props.redlining.geomType !== "LineString" && this.props.redlining.geomType !== "Polygon")}
+        ];
         let editButtons = [
             {key: "Pick", tooltip: "redlining.pick", icon: "pick", data: {action: "Pick", geomType: null, text: ""}},
             {key: "Delete", tooltip: "redlining.delete", icon: "trash", data: {action: "Delete", geomType: null}, disabled: !this.props.redlining.selectedFeature}
@@ -122,7 +128,12 @@ class Redlining extends React.Component {
                     </div>
                     <div className="redlining-group">
                         <div><Message msgId="redlining.draw" /></div>
-                        <ButtonBar buttons={drawButtons} active={activeButton} onClick={(key, data) => this.actionChanged(data)} />
+                        <span>
+                            <ButtonBar buttons={drawButtons} active={activeButton} onClick={(key, data) => this.actionChanged(data)} />
+                            {this.props.redlining.geomType === "LineString" || this.props.redlining.geomType === "Polygon" ?
+                                <ButtonBar buttons={freehandButtons} active={activeFreeHand} onClick={(key, data) => this.actionChanged(data)} /> : null
+                            }
+                        </span>
                     </div>
                     <div className="redlining-group">
                         <div><Message msgId="redlining.edit" /></div>

--- a/plugins/map/RedliningSupport.jsx
+++ b/plugins/map/RedliningSupport.jsx
@@ -73,6 +73,8 @@ class RedliningSupport extends React.Component {
             this.deleteCurrentFeature(this.props);
         } else if(newProps.redlining.action === 'Draw' && (this.props.redlining.action !== 'Draw' || newProps.redlining.geomType !== this.props.redlining.geomType || layerChanged)) {
             this.addDrawInteraction(newProps);
+        } else if(newProps.redlining.freehand !== this.props.redlining.freehand) {
+            this.addDrawInteraction(newProps);
         } else if(newProps.redlining.style !== this.props.redlining.style) {
             this.updateFeatureStyle(newProps.redlining.style);
         }
@@ -106,10 +108,12 @@ class RedliningSupport extends React.Component {
     addDrawInteraction = (newProps) => {
         this.reset();
         let isText = newProps.redlining.geomType === "Text";
+        let isFreeHand = newProps.redlining.freehand;
         let drawInteraction = new ol.interaction.Draw({
             type: isText ? "Point" : newProps.redlining.geomType,
             condition: (event) => {  return event.pointerEvent.buttons === 1 },
-            style: new ol.style.Style()
+            style: new ol.style.Style(),
+            freehand: isFreeHand
         });
         drawInteraction.on('drawstart', (evt) => {
             this.leaveTemporaryPickMode();

--- a/plugins/style/Redlining.css
+++ b/plugins/style/Redlining.css
@@ -22,6 +22,17 @@ div.redlining-group > div {
     white-space: nowrap;
 }
 
+div.redlining-group > span {
+    display: flex;
+    justify-content: center;
+    margin: auto;
+}
+
+div.redlining-group > span > * {
+    flex: 1 0 auto;
+    margin-right: 0.25em;
+}
+
 div.redlining-controlsbar {
     display: flex;
     flex-wrap: wrap;

--- a/translations/data.cs-CZ
+++ b/translations/data.cs-CZ
@@ -159,6 +159,7 @@
       "draw": "",
       "edit": "",
       "fill": "Výplň",
+      "freehand": "",
       "label": "Popisek",
       "layer": "Vrstva",
       "line": "Linie",

--- a/translations/data.de-CH
+++ b/translations/data.de-CH
@@ -159,6 +159,7 @@
       "draw": "Zeichnen",
       "edit": "Bearbeiten",
       "fill": "Füllung",
+      "freehand": "",
       "label": "Beschriftung",
       "layer": "Ebene",
       "line": "Linie",

--- a/translations/data.de-DE
+++ b/translations/data.de-DE
@@ -159,6 +159,7 @@
       "draw": "Zeichnen",
       "edit": "Bearbeiten",
       "fill": "Füllung",
+      "freehand": "",
       "label": "Beschriftung",
       "layer": "Ebene",
       "line": "Linie",

--- a/translations/data.en-US
+++ b/translations/data.en-US
@@ -159,6 +159,7 @@
       "draw": "Draw",
       "edit": "Edit",
       "fill": "Fill",
+      "freehand": "Freehand drawing",
       "label": "Label",
       "layer": "Layer",
       "line": "Line",

--- a/translations/data.es-ES
+++ b/translations/data.es-ES
@@ -159,6 +159,7 @@
       "draw": "",
       "edit": "",
       "fill": "Relleno",
+      "freehand": "",
       "label": "Etiqueta",
       "layer": "Capa",
       "line": "Línea",

--- a/translations/data.fr-FR
+++ b/translations/data.fr-FR
@@ -159,6 +159,7 @@
       "draw": "Dessiner",
       "edit": "Editer",
       "fill": "Remplissage",
+      "freehand": "Dessin à main levée",
       "label": "Texte",
       "layer": "Couche",
       "line": "Ligne",

--- a/translations/data.hu-HU
+++ b/translations/data.hu-HU
@@ -159,6 +159,7 @@
       "draw": "",
       "edit": "",
       "fill": "Kitöltés",
+      "freehand": "",
       "label": "Címke",
       "layer": "",
       "line": "Vonaé",

--- a/translations/data.it-IT
+++ b/translations/data.it-IT
@@ -159,6 +159,7 @@
       "draw": "Disegna",
       "edit": "Modifica",
       "fill": "Riempimento",
+      "freehand": "",
       "label": "Ettichetta",
       "layer": "Layer",
       "line": "Linea",

--- a/translations/data.pl-PL
+++ b/translations/data.pl-PL
@@ -159,6 +159,7 @@
       "draw": "Rysuj",
       "edit": "Edytuj",
       "fill": "Wypełnij",
+      "freehand": "",
       "label": "Etykieta",
       "layer": "Warstwa",
       "line": "Linia",

--- a/translations/data.pt-BR
+++ b/translations/data.pt-BR
@@ -159,6 +159,7 @@
       "draw": "",
       "edit": "",
       "fill": "Preenchimento",
+      "freehand": "",
       "label": "Rótulo",
       "layer": "",
       "line": "Linha",

--- a/translations/data.ro-RO
+++ b/translations/data.ro-RO
@@ -159,6 +159,7 @@
       "draw": "Desenează",
       "edit": "Modifică",
       "fill": "Interior",
+      "freehand": "",
       "label": "Text",
       "layer": "Strat",
       "line": "Linie",

--- a/translations/data.ru-RU
+++ b/translations/data.ru-RU
@@ -159,6 +159,7 @@
       "draw": "",
       "edit": "",
       "fill": "Заливка",
+      "freehand": "",
       "label": "Надпись",
       "layer": "",
       "line": "Линия",

--- a/translations/data.sv-SE
+++ b/translations/data.sv-SE
@@ -159,6 +159,7 @@
       "draw": "Rita",
       "edit": "Redigera",
       "fill": "Fyllning",
+      "freehand": "",
       "label": "Etikett",
       "layer": "Lager",
       "line": "Linje",

--- a/translations/tsconfig.json
+++ b/translations/tsconfig.json
@@ -130,6 +130,7 @@
     "redlining.draw",
     "redlining.edit",
     "redlining.fill",
+    "redlining.freehand",
     "redlining.label",
     "redlining.layer",
     "redlining.line",


### PR DESCRIPTION
Add a button in Redlining tool to enable freehand drawing for LineString and Polygon geometries

Fix https://github.com/qgis/qwc2-demo-app/issues/193
 