### PR TITLE
Improve csv output

### DIFF
--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -220,23 +220,34 @@ class IdentifyViewer extends React.Component {
             let data = JSON.stringify(json, null, ' ');
             FileSaver.saveAs(new Blob([data], {type: "text/plain;charset=utf-8"}), "results.json");
         } else if(this.props.exportFormat.toLowerCase() === 'csv') {
-            let csv = "";
+            let first = false;
             Object.entries(json).forEach(([layerName, features]) => {
-                csv += layerName + "\n";
-                features.forEach(feature => {
-                    Object.entries(feature.properties || {}).forEach(([attrib, value]) => {
+                let csv = "";
+                if (!first) {
+                    Object.entries(features[0].properties || {}).forEach(([attrib]) => {
                         if(attrib !== "htmlContent") {
-                            csv += '\t"' + attrib + '"\t"' + String(value).replace('"', '""') + '"\n';
+                            csv += attrib  + '"\t"' ;
                         }
                     });
-                    if(feature.geometry) {
-                        csv += '\t"geometry"\t"' + stringify(feature.geometry) + '"\n';
+                    if(features[0].geometry) {
+                        csv += '"geometry"\t"';
                     }
+                    first = true;
+                    csv += '"\n"';
+                }
+                features.forEach(feature => {
+                    Object.entries(feature.properties || {}).forEach(([attrib, value]) => {
+                        csv += String(value).replace('"', '""') + '"\t"';
+                    });
+                    if(feature.geometry) {
+                        csv += stringify(feature.geometry) + '"\t"';
+                    }
+                    csv += '"\n"';
                 });
-                csv += "\n";
+                first = false;
+                FileSaver.saveAs(new Blob([csv], {type: "text/csv;charset=UTF-8"}), layerName + ".csv");
             })
-            FileSaver.saveAs(new Blob([csv], {type: "text/plain;charset=utf-8"}), "results.csv");
-        }
+        } 
     }
     resultDisplayName = (layer, result) => {
         let displayName = "";

--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -221,33 +221,37 @@ class IdentifyViewer extends React.Component {
             let data = JSON.stringify(json, null, ' ');
             FileSaver.saveAs(new Blob([data], {type: "text/plain;charset=utf-8"}), "results.json");
         } else if(this.props.exportFormat.toLowerCase() === 'csv') {
-            let first = false;
+            let first = true;
             let file = 0 ;
             let blobs = [];
             let filenames = [];
             Object.entries(json).forEach(([layerName, features]) => {
                 let csv = "";
                 file += 1;
-                if (!first) {
+                if (first) {
                     Object.entries(features[0].properties || {}).forEach(([attrib]) => {
                         if(attrib !== "htmlContent") {
-                            csv += attrib  + '\t' ;
+                            csv += attrib  + ';' ;
                         }
                     });
                     if(features[0].geometry) {
-                        csv += 'geometry\t"';
+                        csv += 'geometry';
+                    } else if(csv !== ""){
+                        csv = csv.slice(0, -1); // Remove trailling semi column ;
                     }
-                    first = true;
-                    csv += '"\n"';
+                    first = false;
+                    csv += '\n';
                 }
                 features.forEach(feature => {
                     Object.entries(feature.properties || {}).forEach(([attrib, value]) => {
-                        csv += String(value).replace('"', '""') + '"\t"';
+                        csv += String(value).replace('"', '""') + ';';
                     });
                     if(feature.geometry) {
-                        csv += stringify(feature.geometry) + '"\t"';
+                        csv += stringify(feature.geometry) + ';';
+                    } else if(csv !== ""){
+                        csv = csv.slice(0, -1); // Remove trailling semi column ;
                     }
-                    csv += '"\n"';
+                    csv += '\n';
                 });
                 first = false;
                 let blob = new Blob([csv], {type: "text/csv;charset=utf-8"});

--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -217,10 +217,27 @@ class IdentifyViewer extends React.Component {
         this.export(filteredResults);
     }
     export = (json) => {
-        if(this.props.exportFormat.toLowerCase() === 'json') {
+        if(this.state.format.toLowerCase() === 'json') {
             let data = JSON.stringify(json, null, ' ');
             FileSaver.saveAs(new Blob([data], {type: "text/plain;charset=utf-8"}), "results.json");
-        } else if(this.props.exportFormat.toLowerCase() === 'csv') {
+        } else if(this.state.format.toLowerCase() === 'csv') {
+            let csv = "";
+            Object.entries(json).forEach(([layerName, features]) => {
+                csv += layerName + "\n";
+                features.forEach(feature => {
+                    Object.entries(feature.properties || {}).forEach(([attrib, value]) => {
+                        if(attrib !== "htmlContent") {
+                            csv += '\t"' + attrib + '"\t"' + String(value).replace('"', '""') + '"\n';
+                        }
+                    });
+                    if(feature.geometry) {
+                        csv += '\t"geometry"\t"' + stringify(feature.geometry) + '"\n';
+                    }
+                });
+                csv += "\n";
+            })
+            FileSaver.saveAs(new Blob([csv], {type: "text/plain;charset=utf-8"}), "results.csv");
+        } else if(this.state.format.toLowerCase() === 'csv + zip') {
             let first = true;
             let file = 0 ;
             let blobs = [];
@@ -253,7 +270,7 @@ class IdentifyViewer extends React.Component {
                     }
                     csv += '\n';
                 });
-                first = false;
+                first = true;
                 let blob = new Blob([csv], {type: "text/csv;charset=utf-8"});
                 blobs.push(blob);
                 filenames.push(layerName);
@@ -269,7 +286,7 @@ class IdentifyViewer extends React.Component {
             } else {
                 FileSaver.saveAs(blobs[0], filenames[0] + ".csv");
             }
-        } 
+        }
     }
     resultDisplayName = (layer, result) => {
         let displayName = "";
@@ -463,6 +480,17 @@ class IdentifyViewer extends React.Component {
                     </div>
                     {attributes}
                     <div className="identify-buttonbox">
+                        {
+                            this.props.exportFormat ?
+                            (<div>
+                                <Message msgId="identify.exportformat" />
+                                <select value={this.state.format} onChange={ev => this.setState({format: ev.target.value})}>
+                                    <option value="json">json</option>
+                                    <option value="csv">csv</option>
+                                    <option value="csv + zip">csv + zip</option>
+                                </select>
+                            </div>) : null
+                        }
                         {this.props.exportFormat ? (<button className="button" onClick={this.exportResults}><Message msgId="identify.export" /></button>) : null}
                     </div>
                 </div>
@@ -486,6 +514,17 @@ class IdentifyViewer extends React.Component {
                         })}
                     </div>
                     <div className="identify-buttonbox">
+                        {
+                            this.props.exportFormat ?
+                            (<div>
+                                <Message msgId="identify.exportformat" />
+                                <select value={this.state.format} onChange={ev => this.setState({format: ev.target.value})}>
+                                    <option value="json">json</option>
+                                    <option value="csv">csv</option>
+                                    <option value="csv + zip">csv + zip</option>
+                                </select>
+                            </div>) : null
+                        }
                         {this.props.exportFormat ? (<button className="button" onClick={this.exportResults}><Message msgId="identify.export" /></button>) : null}
                     </div>
                 </div>

--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -247,7 +247,7 @@ class IdentifyViewer extends React.Component {
                         csv += String(value).replace('"', '""') + ';';
                     });
                     if(feature.geometry) {
-                        csv += stringify(feature.geometry) + ';';
+                        csv += stringify(feature.geometry);
                     } else if(csv !== ""){
                         csv = csv.slice(0, -1); // Remove trailling semi column ;
                     }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "intl": "1.2.5",
         "ismobilejs": "0.5.2",
         "jsts": "2.0.6",
+        "jszip": "3.2.0",
         "lodash.isempty": "4.4.0",
         "lodash.isequal": "4.5.0",
         "lodash.omit": "4.5.0",

--- a/translations/data.en-US
+++ b/translations/data.en-US
@@ -64,6 +64,7 @@
       "querying": "Querying...",
       "noresults": "No information available for the selected point",
       "export": "Export",
+      "exportformat": "Export format :",
       "featureReport": "Feature report",
       "noattributes": "No attributes",
       "title": "Feature Info",

--- a/translations/data.fr-FR
+++ b/translations/data.fr-FR
@@ -64,6 +64,7 @@
       "querying": "Identification en cours...",
       "noresults": "Pas de résultats pour la position sélectionnée",
       "export": "Exporter",
+      "exportformat": "Format d'export :",
       "featureReport": "Données de l'objet",
       "noattributes": "Pas d'attribut",
       "title": "Informations sur l'objet",

--- a/translations/tsconfig.json
+++ b/translations/tsconfig.json
@@ -59,6 +59,7 @@
     "identify.querying",
     "identify.noresults",
     "identify.export",
+    "identify.exportformat",
     "identify.featureReport",
     "identify.noattributes",
     "identify.title",


### PR DESCRIPTION
Generate one csv file per exported layer and zip them for the user.

Before results.csv :
```
parcelle,,
,gid,529100
,id,14118000IB0072
,commune,14118
,prefixe,0
,section,IB
,numero,72
,contenance,36281
,created,2001-09-28
,updated,2015-03-26
,geometry,"MULTIPOLYGON ... "
,,
commune,,
,gid,245
,id,14118
,nom,CAEN
,created,2001-11-22
,updated,2018-04-19
,geometry,"MULTIPOLYGON ... "
```

After commune.csv :
```
gid;id;nom;created;updated;geometry
245;14118;CAEN;2001-11-22;2018-04-19;MULTIPOLYGON ...
302;14327;HEROUVILLE SAINT CLAIR;2002-11-28;2018-04-23;MULTIPOLYGON ...
335;14437;MONDEVILLE;2002-12-05;2016-11-17;MULTIPOLYGON ...
```

Fix https://github.com/qgis/qwc2-demo-app/issues/194