### PR TITLE
Make url and projection configurable for osm sources

### DIFF
--- a/components/map/openlayers/plugins/OSMLayer.js
+++ b/components/map/openlayers/plugins/OSMLayer.js
@@ -14,7 +14,10 @@ let OSMLayer = {
             opacity: options.opacity !== undefined ? options.opacity : 1,
             visible: options.visibility,
             zIndex: options.zIndex,
-            source: new ol.source.OSM()
+            source: new ol.source.OSM({
+                url: options.url,
+                projection: options.projection,
+            })
         });
     }
 };


### PR DESCRIPTION
# Problem

When using layers of `osm` type I'd like to be able to use `tile.openstreetmap.fr` instead of `.org`. 

# Solution

Add support for `options.url` and `options.projection` when creating the `OSMSource`.

Thanks