### PR TITLE
add constraints to all inputs

### DIFF
--- a/components/AutoEditForm.jsx
+++ b/components/AutoEditForm.jsx
@@ -41,12 +41,12 @@ class AutoEditForm extends(React.Component) {
             if(this.props.touchFriendly) {
                 let boolvalue = value == "1" || value == "on" || value == "true" || value === true;
                 input = (
-                    <ToggleSwitch name={field.id} active={boolvalue} onChange={active => this.props.updateField(field.id, active)} />
+                    <ToggleSwitch name={field.id} {...constraints} active={boolvalue} onChange={active => this.props.updateField(field.id, active)} />
                 );
             } else {
                 title = (
                     <label>
-                        <input name={field.id} type="checkbox" checked={value} onChange={ev => this.props.updateField(field.id, ev.target.checked)} />
+                        <input name={field.id} {...constraints} type="checkbox" checked={value} onChange={ev => this.props.updateField(field.id, ev.target.checked)} />
                         {field.name}
                     </label>
                 );
@@ -55,7 +55,7 @@ class AutoEditForm extends(React.Component) {
         else if(constraints.values) {
             input = (
                 <span className="input-frame">
-                    <select name={field.id} value={value} onChange={ev => this.props.updateField(field.id, ev.target.value)}>
+                    <select name={field.id} value={value} onChange={ev => this.props.updateField(field.id, ev.target.value)} required={constraints.required} disabled={constraints.readOnly}>
                         <option value="" disabled>{LocaleUtils.getMessageById(this.context.messages, "editing.select")}</option>
                         {constraints.values.map((item,index) => {
                             let value = "", label = "";
@@ -76,8 +76,8 @@ class AutoEditForm extends(React.Component) {
             let precision = constraints.step > 0 ? Math.ceil(-Math.log10(constraints.step)) : 6;
             input = (
                 <NumericInput name={field.id} mobile={this.props.touchFriendly} strict
-                    min={constraints.min} max={constraints.max}
-                    step={constraints.step || 1} precision={precision}
+                    min={constraints.min} max={constraints.max} readOnly={constraints.readOnly}
+                    step={constraints.step || 1} precision={precision} required={constraints.required}
                     format={nr => String(Number(nr))}
                     value={value} onChange={nr => this.props.updateField(field.id, nr)} />
             );
@@ -96,7 +96,7 @@ class AutoEditForm extends(React.Component) {
             );
         } else if(field.type == "text") {
             input = (
-                <textarea name={field.id} value={value} onChange={(ev) => this.props.updateField(field.id, ev.target.value)}></textarea>
+                <textarea name={field.id} value={value} {...constraints} onChange={(ev) => this.props.updateField(field.id, ev.target.value)}></textarea>
             );
         } else {
             input = (

--- a/components/widgets/ToggleSwitch.jsx
+++ b/components/widgets/ToggleSwitch.jsx
@@ -25,12 +25,12 @@ class ToggleSwitch extends React.Component {
             "toggle-switch-inactive": !this.props.active
         });
         return (
-            <div className={classNames} onClick={() => this.props.onChange(!this.props.active)}>
+            <div className={classNames} onClick={() => {if (!this.props.readOnly) this.props.onChange(!this.props.active)}}>
                 <span className="toggle-switch-yes"><Icon icon="ok" /></span>
                 <span className="toggle-switch-slider"><Icon icon="menu-hamburger" /></span>
                 <span className="toggle-switch-no"><Icon icon="remove" /></span>
                 {/* Ensure toggle switch appears in form.elements */}
-                <input type="checkbox" name={this.props.name} value={this.props.active} style={{visibility: 'none'}} />
+                <input type="checkbox" name={this.props.name} value={this.props.active} checked={this.props.active}  onChange={()=>{}} readOnly={this.props.readOnly} required={this.props.required} style={{visibility: 'none'}} />
             </div>
         );
     }

--- a/components/widgets/style/ToggleSwitch.css
+++ b/components/widgets/style/ToggleSwitch.css
@@ -50,5 +50,6 @@ div.ToggleSwitch.toggle-switch-inactive > span.toggle-switch-yes {
 
 
 div.ToggleSwitch > input {
-    display: none;
+    opacity: 0;
+    width: 1px;
 }


### PR DESCRIPTION
even if in the test there are examples for constraints for ex numeric input -> readOnly or required they were not implemented
the style solution for ToggleSwitch checkbox is a little creepy but on display:none the input is not focusable and the browser can not display the message "Please fill out this field" next to it