### PR TITLE
check if editing selected layer is visible/ make visibility true if i…

### DIFF
--- a/plugins/Editing.jsx
+++ b/plugins/Editing.jsx
@@ -70,23 +70,6 @@ class Editing extends React.Component {
         this.setState({selectedLayerVisibility: null});
     }
 
-    findParents(layer, title) {
-        if (layer) {
-            if (layer.title === title) {
-                return []
-            }
-            if (Array.isArray(layer.sublayers)) {
-                for (let i = 0; i < layer.sublayers.length; i++) {
-                    const childResult = this.findParents(layer.sublayers[i], title)
-                    if (Array.isArray(childResult)) {
-                        return [i].concat(childResult);
-                    }
-                }
-            }
-        }
-    }
-
-
     componentWillReceiveProps(newProps) {
         let themeSublayers = newProps.layers.reduce((accum, layer) => {
             return layer.role === LayerRole.THEME ? accum.concat(LayerUtils.getSublayerNames(layer)) : accum;
@@ -258,8 +241,8 @@ class Editing extends React.Component {
 
     checkVisibility = (selectedLayer, visibility) => {
         if (selectedLayer != null){
-            let layer = this.props.layers.filter(layer => (layer.role === LayerRole.THEME && LayerUtils.searchSubLayer(layer, 'name', selectedLayer)))[0];
-            let path = this.findParents(layer, selectedLayer);
+            let path = [];
+            let layer = this.props.layers.filter(layer => (layer.role === LayerRole.THEME && LayerUtils.searchSubLayer(layer, 'name', selectedLayer, path)))[0];
             let {newsublayer} = LayerUtils.cloneLayer(layer, path);
             let oldvisibility = newsublayer.visibility;
             this.setState({selectedLayerVisibility: oldvisibility});

--- a/plugins/Editing.jsx
+++ b/plugins/Editing.jsx
@@ -86,15 +86,6 @@ class Editing extends React.Component {
         }
     }
 
-    getLayer(layers) {
-
-        for (let i in layers) {
-            if (layers[i].role == 2) {
-                return layers[i]
-            }
-        }
-        return {}
-    }
 
     componentWillReceiveProps(newProps) {
         let themeSublayers = newProps.layers.reduce((accum, layer) => {
@@ -267,10 +258,10 @@ class Editing extends React.Component {
 
     checkVisibility = (selectedLayer, visibility) => {
         if (selectedLayer != null){
-            let layer = this.getLayer(this.props.layers)
-            let path = this.findParents(layer, selectedLayer)
+            let layer = this.props.layers.filter(layer => (layer.role === LayerRole.THEME && LayerUtils.searchSubLayer(layer, 'name', selectedLayer)))[0];
+            let path = this.findParents(layer, selectedLayer);
             let {newsublayer} = LayerUtils.cloneLayer(layer, path);
-            let oldvisibility = newsublayer.visibility
+            let oldvisibility = newsublayer.visibility;
             this.setState({selectedLayerVisibility: oldvisibility});
             let recurseDirection =  !oldvisibility? "both" : "children";
             if (oldvisibility != visibility && visibility != null){


### PR DESCRIPTION
…t is not / restore initial layer visibility state on change selected layer or exit editing


I think it would be useful if the layer selected for editing would become automatically visible if it is not, and when finishing editing or changing the layer for editing to return to the initial state