### PR TITLE
Pass the correct sublayer to maxbbox()

### DIFF
--- a/components/Search.jsx
+++ b/components/Search.jsx
@@ -397,7 +397,7 @@ class Search extends React.Component {
                 const maxbbox = (layer, bounds) => {
                     if (layer.sublayers) {
                         for (const sublayer of layer.sublayers) {
-                            maxbbox(layer.sublayers[sublayer], bounds);
+                            maxbbox(sublayer, bounds);
                         }
                     } else {
                         const newbounds = CoordinatesUtils.reprojectBbox(layer.bbox.bounds, layer.bbox.crs, this.props.map.projection);


### PR DESCRIPTION
This fixes a bug introduced in da23d28ab6. `sublayer` is no longer a key
but a reference to an element in the `layer.sublayers` array.