### PR TITLE
use ol.proj for reprojection and get units

### DIFF
--- a/components/CoordinateDisplayer.jsx
+++ b/components/CoordinateDisplayer.jsx
@@ -9,7 +9,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import proj4js from 'proj4';
 import CoordinatesUtils from '../utils/CoordinatesUtils';
 import LocaleUtils from '../utils/LocaleUtils';
 
@@ -26,7 +25,7 @@ class CoordinateDisplayer extends React.Component {
         if (this.props.mousepos) {
             const coo = CoordinatesUtils.reproject(this.props.mousepos.coordinate, this.props.mapcrs, this.props.displaycrs);
             if (!isNaN(coo[0]) && !isNaN(coo[1])) {
-                const digits = proj4js.defs(this.props.displaycrs).units === 'degrees' ? 4 : 0;
+                const digits = CoordinatesUtils.getUnits(this.props.displaycrs) === 'degrees' ? 4 : 0;
                 value = LocaleUtils.toLocaleFixed(coo[0], digits) + " " + LocaleUtils.toLocaleFixed(coo[1], digits);
             }
         }

--- a/plugins/MapInfoTooltip.jsx
+++ b/plugins/MapInfoTooltip.jsx
@@ -10,7 +10,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {createSelector} from 'reselect';
-import proj4js from 'proj4';
 import axios from 'axios';
 import ConfigUtils from '../utils/ConfigUtils';
 import CoordinatesUtils from '../utils/CoordinatesUtils';
@@ -86,7 +85,7 @@ class MapInfoTooltip extends React.Component {
         }
         projections.map(crs => {
             const coo = CoordinatesUtils.reproject(this.state.coordinate, this.props.map.projection, crs);
-            const digits = proj4js.defs(crs).units === 'degrees' ? 4 : 0;
+            const digits = CoordinatesUtils.getUnits(crs) === 'degrees' ? 4 : 0;
             info.push([
                 (CoordinatesUtils.getAvailableCRS()[crs] || {label: crs}).label,
                 coo.map(x => LocaleUtils.toLocaleFixed(x, digits)).join(", ")

--- a/plugins/Measure.jsx
+++ b/plugins/Measure.jsx
@@ -11,7 +11,6 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {createSelector} from 'reselect';
 import isEmpty from 'lodash.isempty';
-import proj4js from 'proj4';
 import CoordinatesUtils from '../utils/CoordinatesUtils';
 import LocaleUtils from '../utils/LocaleUtils';
 import measureUtils from '../utils/MeasureUtils';
@@ -66,7 +65,7 @@ class Measure extends React.Component {
     renderResult = () => {
         let resultBody = null;
         if (this.props.measureState.geomType === "Point") {
-            const digits = proj4js.defs(this.props.displaycrs).units === 'degrees' ? 4 : 0;
+            const digits = CoordinatesUtils.getUnits(this.props.displaycrs) === 'degrees' ? 4 : 0;
             let text = "0 0";
             if (!isEmpty(this.props.measureState.coordinates)) {
                 const coo = CoordinatesUtils.reproject(this.props.measureState.coordinates, this.props.mapcrs, this.props.displaycrs);

--- a/utils/CoordinatesUtils.js
+++ b/utils/CoordinatesUtils.js
@@ -28,8 +28,8 @@ const CoordinatesUtils = {
         return crsList;
     },
     getUnits(projection) {
-        const proj = new Proj4js.Proj(projection);
-        return proj.units || 'degrees';
+        const proj = ol.proj.get(projection);
+        return proj.getUnits() || 'degrees';
     },
     getAxisOrder(projection) {
         const axis = ol.proj.get(projection).getAxisOrientation();
@@ -39,17 +39,14 @@ const CoordinatesUtils = {
         if (source === dest) {
             return [...point];
         }
-        const sourceProj = Proj4js.defs(source) ? new Proj4js.Proj(source) : null;
-        const destProj = Proj4js.defs(dest) ? new Proj4js.Proj(dest) : null;
-        if (sourceProj && destProj) {
-            const p = Array.isArray(point) ? Proj4js.toPoint(point) : Proj4js.toPoint([point.x, point.y]);
+        if (source && dest) {
             let transformed = null;
             try {
-                transformed = Proj4js.transform(sourceProj, destProj, p);
+                transformed = ol.proj.transform(point, source, dest);
             } catch (e) {
-                transformed = {x: 0, y: 0};
+                transformed = [0, 0];
             }
-            return [transformed.x, transformed.y];
+            return transformed;
         }
         return null;
     },

--- a/utils/IdentifyUtils.js
+++ b/utils/IdentifyUtils.js
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import proj4js from 'proj4';
 import isEmpty from 'lodash.isempty';
 import {LayerRole} from '../actions/layers';
 import CoordinatesUtils from '../utils/CoordinatesUtils';
@@ -52,7 +51,7 @@ const IdentifyUtils = {
         if (CoordinatesUtils.getAxisOrder(map.projection).substr(0, 2) === 'ne' && version === '1.3.0') {
             bbox = [center[1] - dx, center[0] - dy, center[1] + dx, center[0] + dy];
         }
-        const digits = proj4js.defs(map.projection).units === 'degrees' ? 4 : 0;
+        const digits = CoordinatesUtils.getUnits(map.projection).units === 'degrees' ? 4 : 0;
 
         let format = 'text/plain';
         const infoFormats = layer.infoFormats || [];


### PR DESCRIPTION
for fixing https://github.com/qgis/qwc2-demo-app/issues/254 and also for consistency I suggest using ol.proj.transform instead of Proj4js.transform.
from https://github.com/proj4js/proj4js/commit/e4e030847c70a50a81db8704818c58ff6ba96cfa  there is a problem with the transformation on neu axis

proj4: "2.6.0" or less,
Proj4js.transform
EPSG:4326 {x: 23.569485, y: 44.483493}   ---->  EPSG:3844 {x: 386331.41681077797 y: 332533.2419243645}
  
proj4@2.6.1 or higher
 Proj4js.transform
EPSG:4326 {x: 23.569485, y: 44.483493}  ---->  EPSG:3844 {y: 386331.41681077797, x: 332533.2419243645}

there also was a problem with this on WMTS https://github.com/openlayers/openlayers/issues/11076 but it seems it is ok with WMTS rendering

Thanks