### PR TITLE
update @turf/buffer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "BSD-2-Clause",
     "repository": "git@github.com:qgis/qwc2.git",
     "dependencies": {
-        "@turf/buffer": "5.1.5",
+        "@turf/buffer": "6.3.0",
         "axios": "0.21.1",
         "babel-polyfill": "6.26.0",
         "chartist": "0.10.1",


### PR DESCRIPTION
There was an issue with calculating distance in turfjs buffer function (i.e. https://github.com/Turfjs/turf/issues/1246)
With the updated version the distance seems correct.