### PR TITLE
Add XYZ layer to set up its own provider for background layers

### DIFF
--- a/components/map/layers/XYZLayer.js
+++ b/components/map/layers/XYZLayer.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2021 Oslandia SAS <infos+qwc2@oslandia.com>
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import ol from 'openlayers';
+
+export default {
+    create: (options) => {
+        return new ol.layer.Tile({
+            source: new ol.source.XYZ({
+                url: options.url,
+                projection: options.projection
+            })
+        });
+    }
+};

--- a/components/map/layers/index.js
+++ b/components/map/layers/index.js
@@ -17,6 +17,7 @@ import vectorLayer from './VectorLayer';
 import wmsLayer from './WMSLayer';
 import wmtsLayer from './WMTSLayer';
 import wfsLayer from './WFSLayer';
+import xyzLayer from './XYZLayer';
 
 export default {
     bing: bingLayer,
@@ -28,5 +29,6 @@ export default {
     vector: vectorLayer,
     wms: wmsLayer,
     wmts: wmtsLayer,
-    wfs: wfsLayer
+    wfs: wfsLayer,
+    xyz: xyzLayer
 };


### PR DESCRIPTION
Hi @manisandro ,

I want to be able to add my own provider for background layers, without add it in `utils/ConfigProvider.js`. To do so, I need to add XYZLayer with `ol.source.XYZ` configured with the right URL.

Maybe I will need to add some additional options to the source later.

Thanks