### PR TITLE
Remove node-fqdn dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     },
     "devDependencies": {
         "@types/react": "^16.14.0",
-        "node-fqdn": "1.1.1",
         "object-path": "0.11.5",
         "redux-devtools": "3.7.0",
         "redux-devtools-dock-monitor": "1.2.0",


### PR DESCRIPTION
The reason is that `node-fqdn` depends on `deasync` which needs to be
compiled if a prebuilt binary is not available. Doing this is not always
possible/easy, especially on Windows.