### PR TITLE
restore non fractional zoom to it's previous behavior

### DIFF
--- a/components/map/OlMap.jsx
+++ b/components/map/OlMap.jsx
@@ -14,6 +14,7 @@ import isEmpty from 'lodash.isempty';
 import {changeMapView, clickOnMap} from '../../actions/map';
 import {changeMousePositionState} from '../../actions/mousePosition';
 import {setCurrentTask} from '../../actions/task';
+import ConfigUtils from '../../utils/ConfigUtils';
 import MapUtils from '../../utils/MapUtils';
 
 class OlMap extends React.Component {
@@ -52,7 +53,10 @@ class OlMap extends React.Component {
         });
         interactions.extend([
             new ol.interaction.DragPan({kinetic: null}),
-            new ol.interaction.MouseWheelZoom({duration: props.mapOptions.zoomDuration || 250})
+            new ol.interaction.MouseWheelZoom({
+                duration: props.mapOptions.zoomDuration || 250,
+                constrainResolution: ConfigUtils.getConfigProp('allowFractionalZoom') === true ? false : true
+            })
         ]);
         const controls = ol.control.defaults({
             zoom: false,


### PR DESCRIPTION
With "allowFractionalZoom": false in config.json zooming in/out was kind of clunky. In example when zooming in with mousewheel from 1:10000, the scale was still at 1:10000 but the map was zooming in a bit, so zooming to next fixed scale needed a few mousewheel pushes.

By adding the constrainResolution to MouseWheelZoom interaction the previous behavior to get to the next fixed scale should be restored.