### PR TITLE
Fix printing of additional theme layers

### DIFF
--- a/plugins/Print.jsx
+++ b/plugins/Print.jsx
@@ -115,9 +115,26 @@ class Print extends React.Component {
                 printOpacities.push(layer.params.OPACITIES);
                 printColors.push(layer.params.LAYERS.split(",").map(() => "").join(","));
             } else if (this.props.printExternalLayers && layer.role === LayerRole.USERLAYER && layer.visibility && (layer.type === "wms" || layer.type === "wfs")) {
-                printLayers.push(layer.type + ':' + layer.url + "#" + layer.name);
-                printOpacities.push(layer.opacity);
-                printColors.push(layer.color ? layer.color : "");
+                if (layer.type === "wfs") {
+                    // external WFS layer
+                    printLayers.push(layer.type + ':' + layer.url + "#" + layer.name);
+                    printOpacities.push(layer.opacity);
+                    printColors.push(layer.color ? layer.color : "");
+                }
+                else {
+                    // external WMS layer or additional theme layer(s)
+                    if (layer.params.LAYERS) {
+                        let opacities = layer.params.OPACITIES.split(',');
+                        // add single external print layer for every sublayer
+                        layer.params.LAYERS.split(",").forEach((sublayerName, i) => {
+                            // scale sublayer opacity by layer opacity
+                            const opacity = Math.round((opacities[i] || 255) * layer.opacity / 255.0);
+                            printLayers.push(layer.type + ':' + layer.url + "#" + sublayerName);
+                            printOpacities.push(opacity);
+                            printColors.push("");
+                        });
+                    }
+                }
             }
         }
 

--- a/utils/ThemeUtils.js
+++ b/utils/ThemeUtils.js
@@ -80,7 +80,7 @@ const ThemeUtils = {
     createThemeLayer(theme, themes, role = LayerRole.THEME, subLayers = []) {
         const layer = {
             type: "wms",
-            url: theme.url,
+            url: ThemeUtils.fullUrl(theme.url),
             version: theme.version,
             visibility: true,
             expanded: theme.expanded,
@@ -94,9 +94,9 @@ const ThemeUtils = {
             format: theme.format,
             role: role,
             attribution: theme.attribution,
-            legendUrl: theme.legendUrl,
-            printUrl: theme.printUrl,
-            featureInfoUrl: theme.featureInfoUrl,
+            legendUrl: ThemeUtils.fullUrl(theme.legendUrl),
+            printUrl: ThemeUtils.fullUrl(theme.printUrl),
+            featureInfoUrl: ThemeUtils.fullUrl(theme.featureInfoUrl),
             infoFormats: theme.infoFormats,
             externalLayerMap: {
                 ...theme.externalLayerMap,
@@ -138,6 +138,16 @@ const ThemeUtils = {
             return removeDiacritics(item.title).match(filter) || removeDiacritics(item.keywords || "").match(filter) || removeDiacritics(item.abstract || "").match(filter);
         }));
         return matches;
+    },
+    fullUrl(url) {
+        if (url.startsWith('http')) {
+            // keep original URL
+            return url;
+        }
+        else {
+            // full URL for relative URL on current location
+            return new URL(url, window.location.href).href;
+        }
     }
 };
 


### PR DESCRIPTION
Additional theme layers could not be printed as external layers, as they were using only relative WMS URLs and incorrect WMS sublayers.

Fixes:
* change relative URLs of theme layer to full URL on current location
* ~~get theme sublayers from `layer.params.LAYERS` instead of `layer.name`~~ (cf. 007437fc)
* ~~add a separate external print layer for each theme sublayer to support individual layer opacities~~ (cf. 007437fc)

Limitations:
* the full URL must be reachable from QGIS Server to render an external layer
  * Note: use `http://172.17.0.1:8088/` for testing with `qwc-docker` on `localhost`
* only public theme layers can be printed, as the identity is not forwarded
