### PR TITLE
Fix invisible layer query for layer groups

### DIFF
--- a/components/Search.jsx
+++ b/components/Search.jsx
@@ -312,7 +312,7 @@ class Search extends React.Component {
     }
     enableLayer = () => {
         if (this.state.invisibleLayerQuery) {
-            this.props.changeLayerProperty(this.state.invisibleLayerQuery.layer.uuid, "visibility", true, this.state.invisibleLayerQuery.sublayerpath);
+            this.props.changeLayerProperty(this.state.invisibleLayerQuery.layer.uuid, "visibility", true, this.state.invisibleLayerQuery.sublayerpath, "both");
             this.setState({invisibleLayerQuery: null});
         }
     }


### PR DESCRIPTION
Also activate the parent layer group with the "enable invisible layer" function of the search.