### PR TITLE
allow set position of sidebar

### DIFF
--- a/components/SideBar.jsx
+++ b/components/SideBar.jsx
@@ -29,14 +29,17 @@ class SideBar extends React.Component {
         onShow: PropTypes.func,
         setCurrentTask: PropTypes.func,
         title: PropTypes.string,
-        width: PropTypes.string
+        width: PropTypes.string,
+        side: PropTypes.string
     }
     static defaultProps = {
         extraClasses: '',
         onShow: () => {},
         onHide: () => {},
         width: '15em',
-        minWidth: '15em'
+        minWidth: '15em',
+        // allowed values are 'left' and 'right'
+        side: 'right'
     }
     state = {
         render: false
@@ -71,10 +74,23 @@ class SideBar extends React.Component {
         const style = {
             width: this.props.width,
             minWidth: this.props.minWidth,
-            right: 0,
-            transform: visible ? '' : 'translateX(100%) translateX(8px)',
+            transform: '',
+            left: '',
+            right: '',
             zIndex: visible ? 5 : 4
         };
+        let closeIcon;
+        if (this.props.side === "right") {
+            style.transform = visible ? '' : 'translateX(100%) translateX(8px)';
+            style.left = '';
+            style.right = 0;
+            closeIcon = "chevron-right";
+        } else if(this.props.side === "left") {
+            style.transform = visible ? '' : 'translateX(-100%) translateX(-8px)';
+            style.right = '';
+            style.left = 0;
+            closeIcon = "chevron-left"
+        }
         let contents = null;
         if (render && typeof this.props.children === "function") {
             contents = this.props.children();
@@ -95,7 +111,7 @@ class SideBar extends React.Component {
                             <span className="sidebar-titlebar-title">{LocaleUtils.tr(this.props.title)}</span>
                             {this.state.render ? this.props.extraTitlebarContent : null}
                             <span className="sidebar-titlebar-spacer" />
-                            <Icon className="sidebar-titlebar-closeicon" icon="chevron-right" onClick={this.closeClicked}/>
+                            <Icon className="sidebar-titlebar-closeicon" icon={closeIcon} onClick={this.closeClicked}/>
                         </div>
                         <div className="sidebar-body">
                             {body}

--- a/icons/chevron-left.svg
+++ b/icons/chevron-left.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg6"
+   sodipodi:docname="chevron-left.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>uniE080</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2493"
+     inkscape:window-height="1385"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="7.375"
+     inkscape:cx="16"
+     inkscape:cy="16"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0" />
+  <title
+     id="title2">uniE080</title>
+  <path
+     d="m 5.00945,12 10.2851,10.2851 3.696,-3.696 -6.5891,-6.5891 6.5891,-6.5891 -3.696,-3.696 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     style="stroke-width:0.7" />
+</svg>

--- a/plugins/Bookmark.jsx
+++ b/plugins/Bookmark.jsx
@@ -19,7 +19,11 @@ import './style/Bookmark.css';
 class Bookmark extends React.Component {
     static propTypes = {
         task: PropTypes.string,
-        state: PropTypes.object
+        state: PropTypes.object,
+        side: PropTypes.string
+    }
+    static defaultProps = {
+        side: 'right'
     }
     state = {
         bookmarks: [],
@@ -61,6 +65,7 @@ class Bookmark extends React.Component {
         }
         return (
             <SideBar icon="bookmark" id="Bookmark"
+                side={this.props.side}
                 title="appmenu.items.Bookmark" width="20em">
                 <div className="bookmark-body" role="body">
                     <h4>{LocaleUtils.tr("bookmark.manage")}</h4>

--- a/plugins/Editing.jsx
+++ b/plugins/Editing.jsx
@@ -44,11 +44,13 @@ class Editing extends React.Component {
         setCurrentTaskBlocked: PropTypes.func,
         theme: PropTypes.object,
         touchFriendly: PropTypes.bool,
-        width: PropTypes.string
+        width: PropTypes.string,
+        side: PropTypes.string
     }
     static defaultProps = {
         touchFriendly: true,
-        width: "30em"
+        width: "30em",
+        side: 'right'
     }
     state = {
         selectedLayer: null,
@@ -243,7 +245,7 @@ class Editing extends React.Component {
         const minMaxTooltip = this.state.minimized ? LocaleUtils.tr("editing.maximize") : LocaleUtils.tr("editing.minimize");
         const extraTitlebarContent = (<Icon className="editing-minimize-maximize" icon={this.state.minimized ? 'chevron-down' : 'chevron-up'} onClick={ev => this.setState({minimized: !this.state.minimized})} title={minMaxTooltip}/>)
         return (
-            <SideBar extraTitlebarContent={extraTitlebarContent} icon={"editing"} id="Editing" onHide={this.onHide}
+            <SideBar side={this.props.side} extraTitlebarContent={extraTitlebarContent} icon={"editing"} id="Editing" onHide={this.onHide}
                 onShow={this.onShow} title="appmenu.items.Editing" width={this.props.width}>
                 {() => ({
                     body: this.state.minimized ? null : this.renderBody()

--- a/plugins/Help.jsx
+++ b/plugins/Help.jsx
@@ -13,14 +13,16 @@ import SideBar from '../components/SideBar';
 
 class Help extends React.Component {
     static propTypes = {
-        renderBody: PropTypes.func
+        renderBody: PropTypes.func,
+        side: PropTypes.string
     }
     static defaultProps = {
-        renderBody: () => { return null; }
+        renderBody: () => { return null; },
+        side: 'right'
     }
     render() {
         return (
-            <SideBar icon="info" id="Help" title="appmenu.items.Help" width="20em">
+            <SideBar side={this.props.side} icon="info" id="Help" title="appmenu.items.Help" width="20em">
                 {() => ({
                     body: (<div>{this.props.renderBody(this.props)}</div>)
                 })}

--- a/plugins/LayerTree.jsx
+++ b/plugins/LayerTree.jsx
@@ -68,6 +68,7 @@ class LayerTree extends React.Component {
         toggleMapTips: PropTypes.func,
         transparencyIcon: PropTypes.bool,
         width: PropTypes.string,
+        side: PropTypes.string,
         zoomToExtent: PropTypes.func
     }
     static defaultProps = {
@@ -89,7 +90,8 @@ class LayerTree extends React.Component {
         enableServiceInfo: true,
         infoInSettings: true,
         showToggleAllLayersCheckbox: true,
-        transparencyIcon: true
+        transparencyIcon: true,
+        side: 'right',
     }
     state = {
         activemenu: null,
@@ -458,6 +460,7 @@ class LayerTree extends React.Component {
         return (
             <div>
                 <SideBar extraBeforeContent={visibilityCheckbox} extraTitlebarContent={extraTitlebarContent}
+                    side={this.props.side}
                     icon="layers" id="LayerTree"
                     onHide={this.hideLegendTooltip}
                     title="appmenu.items.LayerTree" width={this.state.sidebarwidth || this.props.width}>

--- a/plugins/Print.jsx
+++ b/plugins/Print.jsx
@@ -40,7 +40,8 @@ class Print extends React.Component {
         map: PropTypes.object,
         printExternalLayers: PropTypes.bool, // Caution: requires explicit server-side support!
         scaleFactor: PropTypes.number,
-        theme: PropTypes.object
+        theme: PropTypes.object,
+        side: PropTypes.string
     }
     static defaultProps = {
         printExternalLayers: true,
@@ -49,7 +50,8 @@ class Print extends React.Component {
         defaultDpi: 300,
         defaultScaleFactor: 0.5,
         displayRotation: true,
-        gridInitiallyEnabled: false
+        gridInitiallyEnabled: false,
+        side: 'right'
     }
     state = {
         layout: null,
@@ -319,7 +321,7 @@ class Print extends React.Component {
         const minMaxTooltip = this.state.minimized ? LocaleUtils.tr("print.maximize") : LocaleUtils.tr("print.minimize");
         const extraTitlebarContent = (<Icon className="print-minimize-maximize" icon={this.state.minimized ? 'chevron-down' : 'chevron-up'} onClick={() => this.setState({minimized: !this.state.minimized})} title={minMaxTooltip}/>);
         return (
-            <SideBar extraTitlebarContent={extraTitlebarContent} icon={"print"} id="Print"
+            <SideBar side={this.props.side} extraTitlebarContent={extraTitlebarContent} icon={"print"} id="Print"
                 onHide={this.onHide} onShow={this.onShow} title="appmenu.items.Print"
                 width="20em">
                 {() => ({

--- a/plugins/Share.jsx
+++ b/plugins/Share.jsx
@@ -26,12 +26,14 @@ class Share extends React.Component {
         showLink: PropTypes.bool,
         showQRCode: PropTypes.bool,
         showSocials: PropTypes.bool,
-        state: PropTypes.object
+        state: PropTypes.object,
+        side: PropTypes.string
     }
     static defaultProps = {
         showSocials: true,
         showLink: true,
-        showQRCode: true
+        showQRCode: true,
+        side: 'right'
     }
     state = {
         location: null,
@@ -81,7 +83,7 @@ class Share extends React.Component {
     }
     render() {
         return (
-            <SideBar icon="share" id="Share" onShow={this.onShow}
+            <SideBar side={this.props.side} icon="share" id="Share" onShow={this.onShow}
                 title="appmenu.items.Share" width="20em">
                 {() => ({
                     body: this.renderBody()

--- a/plugins/ThemeSwitcher.jsx
+++ b/plugins/ThemeSwitcher.jsx
@@ -24,12 +24,14 @@ class ThemeSwitcher extends React.Component {
         currentTask: PropTypes.object,
         showLayerAfterChangeTheme: PropTypes.bool,
         themeLayersListWindowSize: PropTypes.object,
-        width: PropTypes.string
+        width: PropTypes.string,
+        side: PropTypes.string
     }
     static defaultProps = {
         width: "50%",
         showLayerAfterChangeTheme: false,
-        themeLayersListWindowSize: {width: 400, height: 300}
+        themeLayersListWindowSize: {width: 400, height: 300},
+        side: 'right'
     }
     state = {
         filter: ""
@@ -49,7 +51,7 @@ class ThemeSwitcher extends React.Component {
         );
         return (
             <div>
-                <SideBar extraTitlebarContent={extraTitlebarContent} icon="themes" id="ThemeSwitcher" minWidth="16em"
+                <SideBar side={this.props.side} extraTitlebarContent={extraTitlebarContent} icon="themes" id="ThemeSwitcher" minWidth="16em"
                     title="appmenu.items.ThemeSwitcher" width={this.props.width}>
                     {() => ({
                         body: (


### PR DESCRIPTION
I offer this to the main project. Through this, it will be possible to configure if sidebar will be on the left or the right side of the application. This is necessary because plain CSS won't preserve correct transition of menu collapsing and expanding since this values are produced dynamically.

Right side stays default.

Configuration option is available through all "sidebar" elements with the prop `side` and one of the values `"right"`/`"left"`.
![image](https://user-images.githubusercontent.com/3714179/135120444-80472cd6-2d04-4423-9022-d156277b6352.png)

