### PR TITLE
add startup task

### DIFF
--- a/components/StandardApp.jsx
+++ b/components/StandardApp.jsx
@@ -141,8 +141,7 @@ class AppInitComponent extends React.Component {
                 }
             });
         });
-        const task = ConfigUtils.getConfigProp("startupTask")
-        console.log(task);
+        const task = ConfigUtils.getConfigProp("startupTask");
         if(task){
             this.props.setCurrentTask(task.key, task.mode, task.mapClickAction);
         }

--- a/components/StandardApp.jsx
+++ b/components/StandardApp.jsx
@@ -29,6 +29,7 @@ import {localConfigLoaded, setStartupParameters} from '../actions/localConfig';
 import {addLayer} from '../actions/layers';
 import {changeSearch} from '../actions/search';
 import {themesLoaded, setCurrentTheme} from '../actions/theme';
+import {setCurrentTask} from '../actions/task';
 
 import ConfigUtils from '../utils/ConfigUtils';
 import CoordinatesUtils from '../utils/CoordinatesUtils';
@@ -140,6 +141,11 @@ class AppInitComponent extends React.Component {
                 }
             });
         });
+        const task = ConfigUtils.getConfigProp("startupTask")
+        if(task){
+            this.props.setCurrentTask(task.key, task.mode, task.mapClickAction);
+        }
+        
     }
     render() {
         return null;
@@ -148,7 +154,8 @@ class AppInitComponent extends React.Component {
 
 const AppInit = connect(state => ({
     mapSize: state.map.size,
-    layers: state.layers.flat
+    layers: state.layers.flat,
+    currentTask: state.task.id
 }), {
     themesLoaded: themesLoaded,
     changeSearch: changeSearch,

--- a/components/StandardApp.jsx
+++ b/components/StandardApp.jsx
@@ -142,6 +142,7 @@ class AppInitComponent extends React.Component {
             });
         });
         const task = ConfigUtils.getConfigProp("startupTask")
+        console.log(task);
         if(task){
             this.props.setCurrentTask(task.key, task.mode, task.mapClickAction);
         }
@@ -158,6 +159,7 @@ const AppInit = connect(state => ({
     currentTask: state.task.id
 }), {
     themesLoaded: themesLoaded,
+    setCurrentTask: setCurrentTask,
     changeSearch: changeSearch,
     setCurrentTheme: setCurrentTheme,
     setStartupParameters: setStartupParameters,


### PR DESCRIPTION
Yet another offering for the main project. Since I had the same requirement for the viewer like it was asked here: https://github.com/qgis/qwc2/pull/142

I tried to solve it like suggested. Hopefully I did it right. Feedback is very welcome.

As suggested in config.json a new setting is added `"startupTask"`

I tested it with different tasks like `{"key": "LayerTree"}` and `{"key": "Measure", "mode": "Polygon", "mapClickAction": "identify"}`

Especially the last one let me think, that I did not solved it completely right because the identify plugin is always triggered while measuring. I couldn't stop it from doing that.

Cheers
C