### PR TITLE
fix identify features in user vector layers

### DIFF
--- a/components/map/OlMap.jsx
+++ b/components/map/OlMap.jsx
@@ -177,11 +177,15 @@ class OlMap extends React.Component {
         }
         const features = [];
         this.map.forEachFeatureAtPixel(pixel, (feature, layer) => {
-            features.push([feature, layer]);
+            features.push({ layer: layer ? layer.get('id') : null,
+                feature: feature.getId(),
+                geomType: feature.getGeometry().getType(),
+                geometry: feature.getGeometry().getCoordinates ? feature.getGeometry().getCoordinates() : null})
         });
-        let data = {
+        const data = {
             coordinate: this.map.getEventCoordinate(event),
             pixel: this.map.getEventPixel(event),
+            features: features,
             modifiers: {
                 alt: event.altKey,
                 ctrl: event.ctrlKey,
@@ -189,17 +193,6 @@ class OlMap extends React.Component {
             },
             button: button
         };
-        if (!isEmpty(features)) {
-            const feature = features[0][0];
-            const layer = features[0][1];
-            data = {
-                ...data,
-                layer: layer ? layer.get('id') : null,
-                feature: feature.getId(),
-                geomType: feature.getGeometry().getType(),
-                geometry: feature.getGeometry().getCoordinates ? feature.getGeometry().getCoordinates() : null
-            };
-        }
         this.props.onClick(data);
     }
     updateMapInfoState = () => {

--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -89,15 +89,21 @@ class Identify extends React.Component {
                 });
             });
 
-            let queryFeature = null;
-            if (this.props.click.feature) {
-                const layer = this.props.layers.find(l => l.id === this.props.click.layer);
-                if (layer && layer.role === LayerRole.USERLAYER && layer.type === "vector" && !isEmpty(layer.features)) {
-                    queryFeature = layer.features.find(feature =>  feature.id === this.props.click.feature);
-                    if (queryFeature && !isEmpty(queryFeature.properties)) {
-                        identifyResults[layer.name] = [queryFeature];
+            if (!isEmpty(this.props.click.features)) {
+                this.props.click.features.forEach((result) => {
+                    const layer = this.props.layers.find(l => l.id === result.layer);
+                    if (layer && layer.role === LayerRole.USERLAYER && layer.type === "vector" && !isEmpty(layer.features)) {
+                        const queryFeature = layer.features.find(feature =>  feature.id === result.feature);
+                        if (queryFeature && !isEmpty(queryFeature.properties)) {
+                            if (!identifyResults[layer.name]) {
+                                identifyResults[layer.name] = [];
+                            }
+                            queryFeature.displayname = queryFeature.properties.name || queryFeature.properties.Name || queryFeature.properties.NAME || queryFeature.properties.label || queryFeature.properties.id || queryFeature.id;
+                            queryFeature.layertitle = layer.title || layer.name || layer.id;
+                            identifyResults[layer.name].push(queryFeature);
+                        }
                     }
-                }
+                });
             }
             this.props.addMarker('identify', clickPoint, '', this.props.map.projection);
             this.setState({identifyResults: identifyResults, pendingRequests: pendingRequests});

--- a/reducers/layers.js
+++ b/reducers/layers.js
@@ -172,13 +172,16 @@ export default function layers(state = defaultState, action) {
         const newLayers = (state.flat || []).concat();
         const idx = newLayers.findIndex(layer => layer.id === layerId);
         if (idx === -1) {
+            const newFeatures = action.features.map(function(f) {
+                return {...f, id: f.id || f.properties.id || uuid.v4()};
+            });
             const newLayer = {
                 ...action.layer,
                 id: layerId,
                 type: 'vector',
                 name: action.layer.name || layerId,
                 uuid: uuid.v4(),
-                features: action.features,
+                features: newFeatures,
                 role: action.layer.role || LayerRole.USERLAYER,
                 queryable: action.layer.queryable || false,
                 visibility: action.layer.visibility || true,


### PR DESCRIPTION
identify features on user vector layers not working. see gifs

Before this pull it can be seen that identify is not working as expected.
![identify before](https://user-images.githubusercontent.com/11608132/137103025-eafe2511-ba5d-4798-beb9-a0d1e771e234.gif)
:

After
![identify after](https://user-images.githubusercontent.com/11608132/137103067-c1db1513-ee48-4832-92be-04da13dfd3eb.gif)

