### PR TITLE
do not check  projection.getExtent() when adding a new wmts layer

### DIFF
--- a/components/map/layers/WMTSLayer.js
+++ b/components/map/layers/WMTSLayer.js
@@ -31,7 +31,7 @@ export default {
                 urls: urls,
                 layer: options.name,
                 format: options.format,
-                projection: projection && projection.getExtent() ? projection : null,
+                projection: projection ? projection : null,
                 matrixSet: options.tileMatrixSet,
                 tileGrid: new ol.tilegrid.WMTS({
                     origin: [options.originX, options.originY],


### PR DESCRIPTION
the proj definition do not contain the projection extent.
If you'll try to import a wmts layer with a custom extension ex EPSG:3844 and the proj def defined in config json the ol.proj.get('EPSG:3844').getExtent() will return null  and the layer will have the map projection, which is not ok if the map has a projection and the layer another

also for the example projections you'll recive null
ol.proj.get('EPSG:21781').getExtent() = null
ol.proj.get('EPSG:2056').getExtent() = null