### PR TITLE
fix AttributeTable first column style

### DIFF
--- a/plugins/style/AttributeTable.css
+++ b/plugins/style/AttributeTable.css
@@ -82,6 +82,12 @@ table.attribtable-table th {
                 inset 0 1px 0 @item_border@;
 }
 
+table.attribtable-table th:first-child {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+}
+
 table.attribtable-table th > span {
     margin: 0 0 -1px -1px;
     padding: 0.25em;
@@ -109,13 +115,13 @@ table.attribtable-table tr:hover {
 }
 
 table.attribtable-table td:first-child {
-    position: relative;
     background-color: @button_bg@;
     align-items: center;
     padding: 0.25em 0.5em;
     background-clip: padding-box;
     position: sticky;
     left: 0;
+    z-index: 1;
 }
 
 table.attribtable-table td:first-child::after {


### PR DESCRIPTION
![Screenshot from 2021-12-28 12-34-32](https://user-images.githubusercontent.com/11608132/147557943-1e1784f5-d40c-48b8-8560-e04a4a6e440c.png)

fix first column sticky position