### PR TITLE
Make search optional in TopBar plugin

### DIFF
--- a/components/map/OlMap.jsx
+++ b/components/map/OlMap.jsx
@@ -68,7 +68,7 @@ class OlMap extends React.Component {
             layers: [],
             controls: controls,
             interactions: interactions,
-            view: this.createView(props.center, props.zoom, props.projection, props.resolutions, props.mapOptions.enableRotation)
+            view: this.createView(props.center, props.zoom, props.projection, props.resolutions, props.mapOptions.enableRotation, props.mapOptions.rotation)
         });
         map.on('moveend', this.updateMapInfoState);
         map.on('singleclick', (event) => this.onClick(0, event.originalEvent, event.pixel));
@@ -125,7 +125,7 @@ class OlMap extends React.Component {
     render() {
         if (this.state.rebuildView) {
             const overviewMap = this.map.getControls().getArray().find(control => control instanceof ol.control.OverviewMap);
-            const view = this.createView(this.props.center, this.props.zoom, this.props.projection, this.props.resolutions, this.props.mapOptions.enableRotation);
+            const view = this.createView(this.props.center, this.props.zoom, this.props.projection, this.props.resolutions, this.props.mapOptions.enableRotation, this.props.mapOptions.rotation);
             if (overviewMap) {
                 overviewMap.getOverviewMap().setView(view);
             }
@@ -207,7 +207,7 @@ class OlMap extends React.Component {
         };
         this.props.onMapViewChanges(c, view.getZoom() || 0, bbox, size, this.props.id, this.props.projection);
     }
-    createView = (center, zoom, projection, resolutions, enableRotation) => {
+    createView = (center, zoom, projection, resolutions, enableRotation, rotation) => {
         const viewOptions = {
             projection: projection,
             center: center,
@@ -215,7 +215,8 @@ class OlMap extends React.Component {
             constrainResolution: ConfigUtils.getConfigProp('allowFractionalZoom') === true ? false : true,
             resolutions: resolutions,
             constrainRotation: false,
-            enableRotation: enableRotation !== false
+            enableRotation: enableRotation !== false,
+            rotation: MapUtils.degreesToRadians(rotation) || 0
         };
         return new ol.View(viewOptions);
     }

--- a/utils/MapUtils.js
+++ b/utils/MapUtils.js
@@ -199,6 +199,16 @@ const MapUtils = {
             }
             return closestIdx;
         }
+    },
+
+    /**
+     * Convert degrees to radians
+     * @param degrees {number}
+     * @return {number} in radians
+     */
+    degreesToRadians(degrees) {
+        const pi = Math.PI
+        return degrees * (pi/180);
     }
 };
 


### PR DESCRIPTION
This change checks if Search element was provided. If not, TopBar does not contain a search.

Only down side is: All elements right next to the search are sliding to the most left next to the logo when search does not exists. What would be a good way to avoid that?