### PR TITLE
fix attachment fileUrl

### DIFF
--- a/components/EditUploadField.jsx
+++ b/components/EditUploadField.jsx
@@ -51,7 +51,7 @@ export default class EditUploadField extends React.Component {
         const fileValue = this.props.value.startsWith("attachment:") ? this.props.value.replace(/attachment:\/\//, '') : "";
         const fileType = mime.lookup(fileValue);
         const editServiceUrl = ConfigUtils.getConfigProp("editServiceUrl");
-        const fileUrl = editServiceUrl + "/" + this.props.dataset + "/attachment?file=" + encodeURIComponent(fileValue);
+        const fileUrl = editServiceUrl + this.props.dataset + "/attachment?file=" + encodeURIComponent(fileValue);
         const constraints = {
             ...this.props.constraints,
             accept: (this.props.constraints.accept || "").split(",").map(ext => mime.lookup(ext)).join(",")


### PR DESCRIPTION
there should not be added / because it already exists in editServiceUrl declaration
end in all other places like    
https://github.com/qgis/qwc2/blob/00f260cb1c1d79abe88596085471684a0d01697b/utils/EditingInterface.js#L50
https://github.com/qgis/qwc2/blob/00f260cb1c1d79abe88596085471684a0d01697b/utils/EditingInterface.js#L150
 https://github.com/qgis/qwc2/blob/00f260cb1c1d79abe88596085471684a0d01697b/utils/EditingInterface.js#L139
https://github.com/qgis/qwc2/blob/00f260cb1c1d79abe88596085471684a0d01697b/utils/EditingInterface.js#L131
  is no / added