### PR TITLE
Set Readonly constraint on text fields

### DIFF
--- a/components/AutoEditForm.jsx
+++ b/components/AutoEditForm.jsx
@@ -88,14 +88,14 @@ export default class AutoEditForm extends React.Component {
         } else if (field.type === "text") {
             if (multiline) {
                 input = (
-                    <textarea name={field.id} onChange={(ev) => this.props.updateField(field.id, ev.target.value)} required={constraints.required} value={value} />
+                    <textarea name={field.id} onChange={(ev) => this.props.updateField(field.id, ev.target.value)} readOnly={constraints.readOnly} required={constraints.required} value={value} />
                 );
             } else {
                 input = (
                     <span className="input-frame">
                         <input name={field.id}
                             onChange={(ev) => this.props.updateField(field.id, ev.target.value)}
-                            required={constraints.required} type={field.type} value={value}/>
+                            readOnly={constraints.readOnly} required={constraints.required} type={field.type} value={value}/>
                     </span>
                 );
             }


### PR DESCRIPTION
Hello, I am Gwendoline Andres,
I work in Oslandia company.
I noticed that readOnly constraints have disappeared from text fields on auto-generated forms.

That why I propose this small fix.

Have a good day,

Cordially
