### PR TITLE
Convert keys to uppercase

### DIFF
--- a/utils/LayerUtils.js
+++ b/utils/LayerUtils.js
@@ -144,7 +144,7 @@ const LayerUtils = {
         const urlQuery = url.parse(layer.url, true).query;
         const urlParams = Object.keys(urlQuery).filter(key => {
             return !["service", "version", "request"].includes(key.toLowerCase());
-        }).reduce((res, key) => ({...res, [key]: urlQuery[key]}), {});
+        }).reduce((res, key) => ({...res, [key.toUpperCase()]: urlQuery[key]}), {});
 
         if (!Array.isArray(layer.sublayers)) {
             return {


### PR DESCRIPTION
Before 75e63ff605 `LayerUtils.buildWMSLayerParams()` was converting
search parameters names to uppercase. In 541ae5a4ab, 75e63ff605 was
partially reverted but conversion of parameters names to uppercase was
not restored. However, other parts of the codebase depend on that
behavior. For example,
https://github.com/qgis/qwc2/blob/9f97cdc76d/utils/IdentifyUtils.js#L48.

This commit restores the original behavior.

Refs: https://github.com/qgis/qwc2/commit/75e63ff605#r69813598