### PR TITLE
fix map staying blank if no permissions on default theme

### DIFF
--- a/components/StandardApp.jsx
+++ b/components/StandardApp.jsx
@@ -94,6 +94,20 @@ class AppInitComponent extends React.Component {
                     if (ConfigUtils.getConfigProp("dontLoadDefaultTheme")) {
                         return;
                     }
+
+                    // Determine default theme, and fallback if not available
+                    let availableThemes = themes.items.map((t) => t.id);
+                    let defaultTheme = themes.defaultTheme;
+                    if (!availableThemes.includes(themes.defaultTheme)) {
+                        console.log(`Default theme (${themes.defaultTheme}) is not available.`);
+                        if (availableThemes.length > 0) {
+                          defaultTheme = themes.items[0].id;
+                          console.log(`Falling back to ${defaultTheme}.`);
+                        } else {
+                          console.log(`No available theme to fallback to.`);
+                        }
+                    }
+
                     theme = ThemeUtils.getThemeById(themes, themes.defaultTheme);
                 }
                 const layerParams = params.l !== undefined ? params.l.split(",").filter(entry => entry) : null;


### PR DESCRIPTION
This works around the issue of map staying blank if the logged user has no permission on the default map. Such a situation easily happens with the stock qwc-map-viewer and qwc-config-generator, which assumes the first project is the default project, not taking into account user permissions.

See https://github.com/qwc-services/qwc-map-viewer/issues/12 for more context.