### PR TITLE
Adaptative edit buttons

### DIFF
--- a/components/AttributeForm.jsx
+++ b/components/AttributeForm.jsx
@@ -72,8 +72,11 @@ class AttributeForm extends React.Component {
             commitBar = (<ButtonBar buttons={commitButtons} onClick={this.onDiscard}/>); /* submit is handled via onSubmit in the form */
         }
 
+        const curConfig = this.props.editConfig;
+        const editPermissions = curConfig.permissions || {};
+
         let deleteBar = null;
-        if (!this.props.newfeature && this.props.editing.feature && !this.props.editing.changed) {
+        if (!this.props.newfeature && this.props.editing.feature && !this.props.editing.changed && editPermissions.deletable !== false) {
             if (!this.state.deleteClicked) {
                 const deleteButtons = [
                     {key: 'Delete', icon: 'trash', label: LocaleUtils.trmsg("editing.delete")}

--- a/components/AttributeForm.jsx
+++ b/components/AttributeForm.jsx
@@ -77,6 +77,7 @@ class AttributeForm extends React.Component {
 
         let deleteBar = null;
         if (!this.props.newfeature && this.props.editing.feature && !this.props.editing.changed && editPermissions.deletable !== false) {
+            // Delete button bar will appear by default if no permissions are defined in editConfig or when deletable permission is set
             if (!this.state.deleteClicked) {
                 const deleteButtons = [
                     {key: 'Delete', icon: 'trash', label: LocaleUtils.trmsg("editing.delete")}

--- a/plugins/AttributeTable.jsx
+++ b/plugins/AttributeTable.jsx
@@ -237,10 +237,11 @@ class AttributeTable extends React.Component {
                         <button className="button" disabled={editing || nolayer} onClick={() => this.reload()} title={LocaleUtils.tr("attribtable.reload")}>
                             <Icon icon="refresh" />
                         </button>
-                        {showAddButton ? (<button className="button" disabled={nolayer || editing || loading || layerChanged} onClick={this.addFeature} title={LocaleUtils.tr("attribtable.addfeature")}>
-                            <Icon icon="plus" />
-                        </button>
-												) : null}
+                        {showAddButton ? (
+                            <button className="button" disabled={nolayer || editing || loading || layerChanged} onClick={this.addFeature} title={LocaleUtils.tr("attribtable.addfeature")}>
+                                <Icon icon="plus" />
+                            </button>
+                        ) : null}
                         <button className="button" disabled={layerChanged || !Object.values(this.state.selectedFeatures).find(entry => entry === true)} onClick={this.zoomToSelection} title={LocaleUtils.tr("attribtable.zoomtoselection")}>
                             <Icon icon="search" />
                         </button>
@@ -258,7 +259,7 @@ class AttributeTable extends React.Component {
                             showDelButton ? (<button className="button" disabled={layerChanged || editing || !Object.values(this.state.selectedFeatures).find(entry => entry === true)} onClick={() => this.setState({confirmDelete: true})} title={LocaleUtils.tr("attribtable.deletefeatures")}>
                                 <Icon icon="trash" />
                             </button>
-														) : null
+                        ) : null
                         )}
                         {this.state.confirmDelete ? (
                             <button className="button edit-discard" onClick={() => this.setState({confirmDelete: false})}>

--- a/plugins/AttributeTable.jsx
+++ b/plugins/AttributeTable.jsx
@@ -215,8 +215,9 @@ class AttributeTable extends React.Component {
         const loading = this.state.loading;
         const editing = this.state.changedFeatureIdx !== null;
         const layerChanged = this.state.selectedLayer !== this.state.loadedLayer;
-				const showAddButton = typeof(editConfig[this.state.loadedLayer]) === 'undefined' || typeof(editConfig[this.state.loadedLayer].permissions) === 'undefined' || editConfig[this.state.loadedLayer].permissions.creatable === true;
-				const showDelButton = typeof(editConfig[this.state.loadedLayer]) === 'undefined' || typeof(editConfig[this.state.loadedLayer].permissions) === 'undefined' || editConfig[this.state.loadedLayer].permissions.deletable === true;
+        const editPermissions = (editConfig[this.state.loadedLayer] || {}).permissions || {};
+        const showAddButton = editPermissions.creatable !== false;
+        const showDelButton = editPermissions.deletable !== false;
         return (
             <ResizeableWindow dockable="bottom" icon="editing" initialHeight={480} initialWidth={800} onClose={this.onClose} title={LocaleUtils.tr("attribtable.title")}>
                 <div className="attribtable-body" role="body">

--- a/plugins/AttributeTable.jsx
+++ b/plugins/AttributeTable.jsx
@@ -215,6 +215,8 @@ class AttributeTable extends React.Component {
         const loading = this.state.loading;
         const editing = this.state.changedFeatureIdx !== null;
         const layerChanged = this.state.selectedLayer !== this.state.loadedLayer;
+				const showAddButton = typeof(editConfig[this.state.loadedLayer]) === 'undefined' || typeof(editConfig[this.state.loadedLayer].permissions) === 'undefined' || editConfig[this.state.loadedLayer].permissions.creatable === true;
+				const showDelButton = typeof(editConfig[this.state.loadedLayer]) === 'undefined' || typeof(editConfig[this.state.loadedLayer].permissions) === 'undefined' || editConfig[this.state.loadedLayer].permissions.deletable === true;
         return (
             <ResizeableWindow dockable="bottom" icon="editing" initialHeight={480} initialWidth={800} onClose={this.onClose} title={LocaleUtils.tr("attribtable.title")}>
                 <div className="attribtable-body" role="body">
@@ -234,9 +236,10 @@ class AttributeTable extends React.Component {
                         <button className="button" disabled={editing || nolayer} onClick={() => this.reload()} title={LocaleUtils.tr("attribtable.reload")}>
                             <Icon icon="refresh" />
                         </button>
-                        <button className="button" disabled={nolayer || editing || loading || layerChanged} onClick={this.addFeature} title={LocaleUtils.tr("attribtable.addfeature")}>
+                        {showAddButton ? (<button className="button" disabled={nolayer || editing || loading || layerChanged} onClick={this.addFeature} title={LocaleUtils.tr("attribtable.addfeature")}>
                             <Icon icon="plus" />
                         </button>
+												) : null}
                         <button className="button" disabled={layerChanged || !Object.values(this.state.selectedFeatures).find(entry => entry === true)} onClick={this.zoomToSelection} title={LocaleUtils.tr("attribtable.zoomtoselection")}>
                             <Icon icon="search" />
                         </button>
@@ -251,9 +254,10 @@ class AttributeTable extends React.Component {
                                 <span>{LocaleUtils.tr("attribtable.delete")}</span>
                             </button>
                         ) : (
-                            <button className="button" disabled={layerChanged || editing || !Object.values(this.state.selectedFeatures).find(entry => entry === true)} onClick={() => this.setState({confirmDelete: true})} title={LocaleUtils.tr("attribtable.deletefeatures")}>
+                            showDelButton ? (<button className="button" disabled={layerChanged || editing || !Object.values(this.state.selectedFeatures).find(entry => entry === true)} onClick={() => this.setState({confirmDelete: true})} title={LocaleUtils.tr("attribtable.deletefeatures")}>
                                 <Icon icon="trash" />
                             </button>
+														) : null
                         )}
                         {this.state.confirmDelete ? (
                             <button className="button edit-discard" onClick={() => this.setState({confirmDelete: false})}>

--- a/plugins/Editing.jsx
+++ b/plugins/Editing.jsx
@@ -153,11 +153,11 @@ class Editing extends React.Component {
         }
 
         const actionButtons = [];
-        if (isEmpty(editPermissions) || editPermissions.updatable === true || editPermissions.deletable === true) {
+        if ( editPermissions.updatable !== false || editPermissions.deletable !== false) {
             // Pick button will appear by default if no permissions are defined in theme editConfig or when updatable or deletable permissions are set
             actionButtons.push({key: 'Pick', icon: 'pick', label: LocaleUtils.trmsg("editing.pick"), data: {action: 'Pick', geomReadOnly: false}});
         }
-        if (isEmpty(editPermissions) || editPermissions.creatable === true) {
+        if ( editPermissions.creatable !== false) {
             // Draw button will appear by default if no permissions are defined in theme editConfig or when creatable permission is set
             actionButtons.push({key: 'Draw', icon: 'editdraw', label: LocaleUtils.trmsg("editing.draw"), data: {action: 'Draw', feature: null, geomReadOnly: false}});
         }

--- a/plugins/Editing.jsx
+++ b/plugins/Editing.jsx
@@ -143,6 +143,7 @@ class Editing extends React.Component {
         }
         const editConfig = this.props.theme.editConfig;
         const curConfig = editConfig[this.state.selectedLayer];
+        const editPermissions = curConfig.permissions || {};
         if (!curConfig) {
             return (
                 <div role="body" style={{padding: "1em"}}>
@@ -152,11 +153,11 @@ class Editing extends React.Component {
         }
 
         const actionButtons = [];
-        if (typeof(curConfig.permissions) === 'undefined' || curConfig.permissions.updatable === true || curConfig.permissions.deletable === true) {
+        if (isEmpty(editPermissions) || editPermissions.updatable === true || editPermissions.deletable === true) {
             // Pick button will appear by default if no permissions are defined in theme editConfig or when updatable or deletable permissions are set
             actionButtons.push({key: 'Pick', icon: 'pick', label: LocaleUtils.trmsg("editing.pick"), data: {action: 'Pick', geomReadOnly: false}});
         }
-        if (typeof(curConfig.permissions) === 'undefined' || curConfig.permissions.creatable === true) {
+        if (isEmpty(editPermissions) || editPermissions.creatable === true) {
             // Draw button will appear by default if no permissions are defined in theme editConfig or when creatable permission is set
             actionButtons.push({key: 'Draw', icon: 'editdraw', label: LocaleUtils.trmsg("editing.draw"), data: {action: 'Draw', feature: null, geomReadOnly: false}});
         }

--- a/plugins/Editing.jsx
+++ b/plugins/Editing.jsx
@@ -151,10 +151,15 @@ class Editing extends React.Component {
             );
         }
 
-        const actionButtons = [
-            {key: 'Pick', icon: 'pick', label: LocaleUtils.trmsg("editing.pick"), data: {action: 'Pick'}},
-            {key: 'Draw', icon: 'editdraw', label: LocaleUtils.trmsg("editing.draw"), data: {action: 'Draw', feature: null}}
-        ];
+        const actionButtons = [];
+        if (typeof(curConfig.permissions) === 'undefined' || curConfig.permissions.updatable === true || curConfig.permissions.deletable === true) {
+            // Pick button will appear by default if no permissions are defined in theme editConfig or when updatable or deletable permissions are set
+            actionButtons.push({key: 'Pick', icon: 'pick', label: LocaleUtils.trmsg("editing.pick"), data: {action: 'Pick', geomReadOnly: false}});
+        }
+        if (typeof(curConfig.permissions) === 'undefined' || curConfig.permissions.creatable === true) {
+            // Draw button will appear by default if no permissions are defined in theme editConfig or when creatable permission is set
+            actionButtons.push({key: 'Draw', icon: 'editdraw', label: LocaleUtils.trmsg("editing.draw"), data: {action: 'Draw', feature: null, geomReadOnly: false}});
+        }
         if (ConfigUtils.havePlugin("AttributeTable")) {
             actionButtons.push({key: 'AttribTable', icon: 'editing', label: LocaleUtils.trmsg("editing.attrtable"), data: {action: 'AttrTable'}});
         }
@@ -222,7 +227,6 @@ class Editing extends React.Component {
                 />
             );
         }
-
         const themeSublayers = this.props.layers.reduce((accum, layer) => {
             return layer.role === LayerRole.THEME ? accum.concat(LayerUtils.getSublayerNames(layer)) : accum;
         }, []);


### PR DESCRIPTION
Hello,

I am Gwendoline Andres, I work in Oslandia company. 

I propose this PR to deal with Edit buttons.
I work with qwc_services so I can specify if a writable layer is creatable, updatable or deletable.
But in QWC2 interface, Edit buttons (`Draw`, `Pick` and `Delete`) are always shown even if you are not allowed to make the action. 
You have a message "Dataset is not creatable" (for example) only at the end of your action. 

So I propose this PR to be able to set creatable, updatable and deletable permissions in Edit configuration file and show edit buttons or not. 

If creatable permission is set, `Draw` button in edit interface, and `Add` button in attribute table will appear. 
If updatable permission is set, `Pick` button in edit interface will be shown. 
If deletable permission is set, `Delete` buttons in edit interface and attribute table will appear, and `Pick` button in edit interface (to be abble to get `Delete` button).

I am wondering how to deal with updatable permision and edit form. I hesitate to hide `Accept` button when you are not allowed to update layer. But I think it could be confusing for users. Get the message "Dataset is not updatable" seems clearer. What do you think about that ? 


Next I will propose PR related to this one in qwc2-demo-app and qwc-config-generator.

I hope I manage to explain everything. 

Have a good day, 

Gwendoline Andres
