### PR TITLE
Fix "csv + zip" export

### DIFF
--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -233,7 +233,7 @@ class IdentifyViewer extends React.Component {
                         csv += String(value).replace('"', '""') + ';';
                     });
                     if (feature.geometry) {
-                        csv += JSON.stringify(feature.geometry);
+                        csv += VectorLayerUtils.geoJSONGeomToWkt(feature.geometry);
                     } else if (csv !== "") {
                         csv = csv.slice(0, -1); // Remove trailling semi column ;
                     }

--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -233,7 +233,7 @@ class IdentifyViewer extends React.Component {
                         csv += String(value).replace('"', '""') + ';';
                     });
                     if (feature.geometry) {
-                        csv += stringify(feature.geometry);
+                        csv += JSON.stringify(feature.geometry);
                     } else if (csv !== "") {
                         csv = csv.slice(0, -1); // Remove trailling semi column ;
                     }


### PR DESCRIPTION
Fix for broken "csv + zip" export. Change `stringify` function to `VectorLayerUtils.geoJSONGeomToWkt` for "csv + zip" export like normal csv export.