### PR TITLE
Add key to EditComboField

### DIFF
--- a/components/QtDesignerForm.jsx
+++ b/components/QtDesignerForm.jsx
@@ -226,7 +226,7 @@ class QtDesignerForm extends React.Component {
                 const keyvalrel = this.props.mapPrefix + parts[count - 3] + ":" + parts[count - 2] + ":" + parts[count - 1];
                 return (
                     <EditComboField
-                        editIface={this.props.iface} fieldId={fieldId} keyvalrel={keyvalrel}
+                        key={fieldId} editIface={this.props.iface} fieldId={fieldId} keyvalrel={keyvalrel}
                         name={nametransform(attrname)} readOnly={readOnly} required={required}
                         updateField={updateField} value={value} />
                 );


### PR DESCRIPTION
Hello, 

I notice that in a special case EditComboField list is not refresh. 
In edit form, when I use tabs and if I have two (or more) ComboBox on the same rank in my tabs, option list stay the same even if it is'nt in my QGIS project. I work with keyval relations. 

[Screenshot here.](https://wtf.roflcopter.fr/pics/CV2DJnAT/VoZ50ESk.png)

Adding a key attribute in EditComboField solve this problem (componentDidMount function is called when you switch tab). 

I propose to set the value at `fieldId`, but I can change if there is a better solution. 

Have a good day, 

Gwendoline Andres