### PR TITLE
Add MVT as source of layers

### DIFF
--- a/components/map/layers/MVTLayer.js
+++ b/components/map/layers/MVTLayer.js
@@ -7,10 +7,11 @@
  */
 
 import ol from 'openlayers';
+import { applyStyle } from 'ol-mapbox-style';
 
 export default {
     create: (options) => {
-        return new ol.layer.VectorTile({
+        const layer = new ol.layer.VectorTile({
             source: new ol.source.VectorTile({
                 minZoom: options.minZoom ? options.minZoom : 0,
                 maxZoom: options.maxZoom ? options.maxZoom : 18,
@@ -19,5 +20,13 @@ export default {
                 url: options.url
             })
         });
+        if (options.style) {
+            fetch(options.style).then(function(response) {
+                response.json().then(function(glStyle) {
+                    applyStyle(layer, glStyle, Object.keys(glStyle.sources)[0]);
+                });
+            });
+        }
+        return layer;
     }
 };

--- a/components/map/layers/MVTLayer.js
+++ b/components/map/layers/MVTLayer.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2022 Oslandia SAS <infos+qwc2@oslandia.com>
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import ol from 'openlayers';
+
+export default {
+    create: (options) => {
+        return new ol.layer.VectorTile({
+            source: new ol.source.VectorTile({
+                minZoom: options.minZoom ? options.minZoom : 0,
+                maxZoom: options.maxZoom ? options.maxZoom : 18,
+                projection: options.projection ? options.projection : 'EPSG:3857',
+                format: new ol.format.MVT({}),
+                url: options.url
+            })
+        });
+    }
+};

--- a/components/map/layers/index.js
+++ b/components/map/layers/index.js
@@ -10,6 +10,7 @@
 import bingLayer from './BingLayer';
 import googleLayer from './GoogleLayer';
 import graticuleLayer from './GraticuleLayer';
+import mvtLayer from './MVTLayer';
 import osmLayer from './OSMLayer';
 import overlayLayer from './OverlayLayer';
 import tileproviderLayer from './TileProviderLayer';
@@ -23,6 +24,7 @@ export default {
     bing: bingLayer,
     google: googleLayer,
     graticule: graticuleLayer,
+    mvt: mvtLayer,
     osm: osmLayer,
     overlay: overlayLayer,
     tileprovider: tileproviderLayer,

--- a/libs/openlayers.js
+++ b/libs/openlayers.js
@@ -21,6 +21,7 @@ import OlFormatGML2 from 'ol/format/GML2';
 import OlFormatGML3 from 'ol/format/GML3';
 import OlFormatGML32 from 'ol/format/GML32';
 import OlFormatKML from 'ol/format/KML';
+import OlFormatMVT from 'ol/format/MVT';
 import OlFormatWFS from 'ol/format/WFS';
 import OlFormatWMSCapabilities from 'ol/format/WMSCapabilities';
 import OlFormatWMTSCapabilities from 'ol/format/WMTSCapabilities';
@@ -49,6 +50,7 @@ import OlLayer from 'ol/layer/Layer';
 import OlLayerImage from 'ol/layer/Image';
 import OlLayerTile from 'ol/layer/Tile';
 import OlLayerVector from 'ol/layer/Vector';
+import OlLayerVectorTile from 'ol/layer/VectorTile';
 import OlLayerGroup from 'ol/layer/Group';
 import * as OlLoadingstrategy from 'ol/loadingstrategy';
 import OlMap from 'ol/Map';
@@ -60,6 +62,7 @@ import OlSourceImageWMS from 'ol/source/ImageWMS';
 import OlSourceOSM from 'ol/source/OSM';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 import OlSourceVector from 'ol/source/Vector';
+import OlSourceVectorTile from 'ol/source/VectorTile';
 import OlSourceWMTS from 'ol/source/WMTS';
 import OlSourceXYZ from 'ol/source/XYZ';
 import * as OlSphere from 'ol/sphere';
@@ -97,6 +100,7 @@ export default {
         GML3: OlFormatGML3,
         GML32: OlFormatGML32,
         KML: OlFormatKML,
+        MVT: OlFormatMVT,
         WFS: OlFormatWFS,
         WMSCapabilities: OlFormatWMSCapabilities,
         WMTSCapabilities: OlFormatWMTSCapabilities,
@@ -131,6 +135,7 @@ export default {
         Image: OlLayerImage,
         Tile: OlLayerTile,
         Vector: OlLayerVector,
+        VectorTile: OlLayerVectorTile,
         Group: OlLayerGroup
     },
     loadingstrategy: OlLoadingstrategy,
@@ -144,6 +149,7 @@ export default {
         OSM: OlSourceOSM,
         TileWMS: OlSourceTileWMS,
         Vector: OlSourceVector,
+        VectorTile: OlSourceVectorTile,
         WMTS: OlSourceWMTS,
         XYZ: OlSourceXYZ
     },


### PR DESCRIPTION
Hi,

This PR to be able to add new MVT source as background layer.

Here are some examples of background layers you could use in `themesConfig.json` :

```json
            {
                "name":"IGN_parcellaire",
                "title":"IGN Parcellaire (Vector Tiles)",
                "type":"mvt",
                "source":"IGN",
                "url":"https://wxs.ign.fr/parcellaire/geoportail/tms/1.0.0/PCI/{z}/{x}/{y}.pbf",
                "thumbnail":"default.jpg",
                "attribution":"IGN",
                "attributionUrl":"https://geoservices.ign.fr"
            },
            {
              "name":"PLAN.IGN",
              "title":"PLAN IGN (Vector Tiles)",
              "type":"mvt",
              "source":"IGN",
              "maxZoom": 19,
              "url":"https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf",
              "thumbnail":"default.jpg",
              "attribution":"IGN",
              "attributionUrl":"https://geoservices.ign.fr"
            },
            {
              "name":"world_basemap",
              "title":"World Basemap",
              "type":"mvt",
              "source":"ArcGIS",
              "url":"https://basemaps.arcgis.com/v1/arcgis/rest/services/World_Basemap/VectorTileServer/tile/{z}/{y}/{x}.pbf",
              "thumbnail":"default.jpg",
              "attribution":"ESRI"
            },
```

I am looking at how to add some user-defined styles to these sources.

Thanks