### PR TITLE
fix: empty style on sublayer is rendered as undefined

### DIFF
--- a/plugins/Map.jsx
+++ b/plugins/Map.jsx
@@ -82,7 +82,7 @@ class MapPlugin extends React.Component {
                             // Compress with previous renderlayer
                             renderLayers[renderLayers.length - 1].params.LAYERS += "," + sublayers[i];
                             renderLayers[renderLayers.length - 1].params.OPACITIES += "," + opacities[i];
-                            renderLayers[renderLayers.length - 1].params.STYLES += "," + styles[i] || "";
+                            renderLayers[renderLayers.length - 1].params.STYLES += "," + (styles[i] || "");
                         } else {
                             // Add new renderlayer
                             renderLayers.push({


### PR DESCRIPTION
If `styles[i]` on a sublayer is undefined it'll render as undefined in the request.

I admit this use case happened after a `changeLayerProperty` dispatch with the key `STYLE` not containing any comma but just a single value while having multiple visible sublayers, shouldn't happen that much but feel this fix still makes sense from a code point of view.