### PR TITLE
fix small bug preventing to use displayfield

### DIFF
--- a/utils/IdentifyUtils.js
+++ b/utils/IdentifyUtils.js
@@ -145,7 +145,7 @@ const IdentifyUtils = {
     determineDisplayName(layer, layername, item) {
         const properties = item.properties || {};
         if (item.displayfield) {
-            if (properties[item.displayField] && (properties[item.displayField][0] !== "<")) {
+            if (properties[item.displayfield] && (properties[item.displayfield][0] !== "<")) {
                 return properties[item.displayfield];
             }
         }


### PR DESCRIPTION
Fixes a minor typo (`displayField` instead of `displayfield`) that prevents QWC from using the display field configured in the QGIS project