### PR TITLE
Update renderLayers in Map.jsx

### DIFF
--- a/plugins/Map.jsx
+++ b/plugins/Map.jsx
@@ -179,6 +179,9 @@ class MapPlugin extends React.Component {
         return this.state.renderLayers.map(layer => {
             ++zIndex;
             const options = {...layer, zIndex: zIndex};
+            if (layer.zIndex !== undefined) {
+                options.zIndex = layer.zIndex;
+            }
             const swipe = this.props.swipe !== null && layer === this.state.swipeLayer;
             return (
                 <OlLayer key={layer.uuid} options={options} swipe={swipe ? this.props.swipe : null} />

--- a/plugins/Map.jsx
+++ b/plugins/Map.jsx
@@ -178,10 +178,7 @@ class MapPlugin extends React.Component {
         let zIndex = 0;
         return this.state.renderLayers.map(layer => {
             ++zIndex;
-            const options = {...layer, zIndex: zIndex};
-            if (layer.zIndex !== undefined) {
-                options.zIndex = layer.zIndex;
-            }
+            const options = {...layer, zIndex: layer.zIndex ?? zIndex};
             const swipe = this.props.swipe !== null && layer === this.state.swipeLayer;
             return (
                 <OlLayer key={layer.uuid} options={options} swipe={swipe ? this.props.swipe : null} />


### PR DESCRIPTION
In the renderLayer function the zIndex is set in the loop starting from 0, incrementally increased and set as options.zIndex.  The layer.zIndex can be defined in MeasurementSupport.jsx or EditingSupport.jsx and others, but is not used to render the layers. So the layer order isn't influenced by setting layer.zIndex. Due to that, the marker-icon from height profile renders underneath the profile line.
I added a short if clause to use the value of layer.zIndex. 