### PR TITLE
Allow ResizeableWindow to be docked to any side

### DIFF
--- a/components/ResizeableWindow.jsx
+++ b/components/ResizeableWindow.jsx
@@ -150,10 +150,7 @@ class ResizeableWindow extends React.Component {
         const dockSide = this.props.dockable === true ? "left" : this.props.dockable;
         const dockIconSuffix = (dockSide === "bottom" || dockSide === "top") ? "_bottom" : "";
         let dockIcon = docked ? 'undock' : 'dock';
-        if (dockSide === "right" || dockSide === "top") {
-            dockIcon = docked? 'dock' : 'undock';
-        }
-        dockIcon = dockIcon + dockIconSuffix;
+        dockIcon = dockIcon + "_" + dockSide;
 
         const content = [
             (<div className="resizeable-window-titlebar" key="titlebar" onDoubleClick={this.toggleMaximize} ref={el => { this.titlebar = el; }}>

--- a/components/ResizeableWindow.jsx
+++ b/components/ResizeableWindow.jsx
@@ -9,10 +9,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import {connect} from 'react-redux';
-import {Rnd} from 'react-rnd';
+import { connect } from 'react-redux';
+import { Rnd } from 'react-rnd';
 import uuid from 'uuid';
-import {raiseWindow, registerWindow, unregisterWindow} from '../actions/windows';
+import { raiseWindow, registerWindow, unregisterWindow } from '../actions/windows';
 import ConfigUtils from '../utils/ConfigUtils';
 import LocaleUtils from '../utils/LocaleUtils';
 import Icon from './Icon';
@@ -64,7 +64,7 @@ class ResizeableWindow extends React.Component {
         minimizeable: false,
         visible: true,
         dockable: true,
-        onGeometryChanged: () => {}
+        onGeometryChanged: () => { }
     }
     state = {
         geometry: null
@@ -97,10 +97,10 @@ class ResizeableWindow extends React.Component {
     }
     componentDidMount() {
         this.props.registerWindow(this.id);
-        const newGeomState = {...this.state.geometry};
+        const newGeomState = { ...this.state.geometry };
         if (this.props.initiallyDocked) {
             newGeomState.docked = true;
-            this.setState({geometry: newGeomState});
+            this.setState({ geometry: newGeomState });
         }
         this.props.onGeometryChanged(newGeomState);
     }
@@ -142,12 +142,18 @@ class ResizeableWindow extends React.Component {
             "resizeable-window-body-scrollable": this.props.scrollable,
             "resizeable-window-body-nonscrollable": !this.props.scrollable
         });
-        const style = {display: this.props.visible ? 'initial' : 'none'};
+        const style = { display: this.props.visible ? 'initial' : 'none' };
         const maximized = this.state.geometry.maximized ? true : false;
         const minimized = this.state.geometry.minimized ? true : false;
         const zIndex = 10 + this.props.windowStacking.findIndex(item => item === this.id);
-        const dockBottom  = this.props.dockable === "bottom";
-        const dockIconSuffix = dockBottom ? "_bottom" : "";
+        let docked = this.state.geometry.docked;
+        const dockSide = this.props.dockable === true ? "left" : this.props.dockable;
+        const dockIconSuffix = (dockSide === "bottom" || dockSide === "top") ? "_bottom" : "";
+        let dockIcon = docked ? 'undock' : 'dock';
+        if (dockSide === "right" || dockSide === "top") {
+            dockIcon = docked? 'dock' : 'undock';
+        }
+        dockIcon = dockIcon + dockIconSuffix;
 
         const content = [
             (<div className="resizeable-window-titlebar" key="titlebar" onDoubleClick={this.toggleMaximize} ref={el => { this.titlebar = el; }}>
@@ -162,7 +168,7 @@ class ResizeableWindow extends React.Component {
                 ))}
                 {!maximized && dockable ? (
                     <Icon
-                        className="resizeable-window-titlebar-control" icon={(this.state.geometry.docked ? "undock" : "dock") + dockIconSuffix}
+                        className="resizeable-window-titlebar-control" icon={dockIcon}
                         onClick={this.toggleDock}
                         titlemsgid={this.state.geometry.docked ? LocaleUtils.trmsg("window.undock") : LocaleUtils.trmsg("window.dock")} />
                 ) : null}
@@ -171,7 +177,7 @@ class ResizeableWindow extends React.Component {
                 {this.props.onClose ? (<Icon className="resizeable-window-titlebar-control" icon="remove" onClick={this.onClose} titlemsgid={LocaleUtils.trmsg("window.close")} />) : null}
             </div>),
             (<div className={bodyclasses} key="body" onMouseDown={(ev) => { this.stopEvent(ev); this.props.raiseWindow(this.id); }} onMouseUp={this.stopEvent} onTouchStart={this.stopEvent}>
-                <div className="resizeable-window-drag-shield" ref={el => {this.dragShield = el; }} />
+                <div className="resizeable-window-drag-shield" ref={el => { this.dragShield = el; }} />
                 {this.renderRole("body")}
             </div>)
         ];
@@ -180,8 +186,10 @@ class ResizeableWindow extends React.Component {
             "resizeable-window": true,
             "resizeable-window-maximized": this.state.geometry.maximized,
             "resizeable-window-minimized": this.state.geometry.minimized,
-            "resizeable-window-docked-left": this.state.geometry.docked && !dockBottom && !this.state.geometry.maximized,
-            "resizeable-window-docked-bottom": this.state.geometry.docked && dockBottom && !this.state.geometry.maximized
+            "resizeable-window-docked-left": this.state.geometry.docked && dockSide === "left" && !this.state.geometry.maximized,
+            "resizeable-window-docked-right": this.state.geometry.docked && dockSide === "right" && !this.state.geometry.maximized,
+            "resizeable-window-docked-top": this.state.geometry.docked && dockSide === "top" && !this.state.geometry.maximized,
+            "resizeable-window-docked-bottom": this.state.geometry.docked && dockSide === "bottom" && !this.state.geometry.maximized
         });
         let resizeMode = {
             left: true,
@@ -197,9 +205,10 @@ class ResizeableWindow extends React.Component {
             resizeMode = false;
         } else if (this.state.geometry.docked) {
             resizeMode = {
-                right: !dockBottom,
-                top: dockBottom,
-                bottom: !dockBottom
+                left: dockSide === "right",
+                right: dockSide === "left",
+                top: dockSide === "bottom",
+                bottom: dockSide !== "bottom"
             };
         }
         return (
@@ -213,7 +222,7 @@ class ResizeableWindow extends React.Component {
                     onDragStop={this.onDragStop}
                     onMouseDown={() => this.props.raiseWindow(this.id)}
                     onResizeStop={this.onResizeStop}
-                    ref={c => { this.rnd = c; }} style={{zIndex: zIndex}}>
+                    ref={c => { this.rnd = c; }} style={{ zIndex: zIndex }}>
                     {content}
                 </Rnd>
             </div>
@@ -225,8 +234,8 @@ class ResizeableWindow extends React.Component {
         }
     }
     onDragStop = (ev, data) => {
-        const geometry = {...this.state.geometry, x: data.x, y: data.y};
-        this.setState({geometry: geometry});
+        const geometry = { ...this.state.geometry, x: data.x, y: data.y };
+        this.setState({ geometry: geometry });
         if (this.dragShield) {
             this.dragShield.style.display = 'none';
         }
@@ -239,21 +248,21 @@ class ResizeableWindow extends React.Component {
             width: this.state.geometry.width + delta.width,
             height: this.state.geometry.height + delta.height
         };
-        this.setState({geometry: geometry});
+        this.setState({ geometry: geometry });
     }
     toggleDock = () => {
         const geometry = {
             ...this.state.geometry,
             docked: !this.state.geometry.docked
         };
-        this.setState({geometry: geometry});
+        this.setState({ geometry: geometry });
     }
     toggleMinimize = () => {
         const geometry = {
             ...this.state.geometry,
             minimized: !this.state.geometry.minimized
         };
-        this.setState({geometry: geometry});
+        this.setState({ geometry: geometry });
     }
     toggleMaximize = () => {
         const geometry = {
@@ -261,7 +270,7 @@ class ResizeableWindow extends React.Component {
             maximized: !this.state.geometry.maximized,
             minimized: false
         };
-        this.setState({geometry: geometry});
+        this.setState({ geometry: geometry });
     }
 }
 

--- a/components/ResizeableWindow.jsx
+++ b/components/ResizeableWindow.jsx
@@ -9,10 +9,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { connect } from 'react-redux';
-import { Rnd } from 'react-rnd';
+import {connect} from 'react-redux';
+import {Rnd} from 'react-rnd';
 import uuid from 'uuid';
-import { raiseWindow, registerWindow, unregisterWindow } from '../actions/windows';
+import {raiseWindow, registerWindow, unregisterWindow} from '../actions/windows';
 import ConfigUtils from '../utils/ConfigUtils';
 import LocaleUtils from '../utils/LocaleUtils';
 import Icon from './Icon';
@@ -64,7 +64,7 @@ class ResizeableWindow extends React.Component {
         minimizeable: false,
         visible: true,
         dockable: true,
-        onGeometryChanged: () => { }
+        onGeometryChanged: () => {}
     }
     state = {
         geometry: null
@@ -97,10 +97,10 @@ class ResizeableWindow extends React.Component {
     }
     componentDidMount() {
         this.props.registerWindow(this.id);
-        const newGeomState = { ...this.state.geometry };
+        const newGeomState = {...this.state.geometry};
         if (this.props.initiallyDocked) {
             newGeomState.docked = true;
-            this.setState({ geometry: newGeomState });
+            this.setState({geometry: newGeomState});
         }
         this.props.onGeometryChanged(newGeomState);
     }
@@ -142,7 +142,7 @@ class ResizeableWindow extends React.Component {
             "resizeable-window-body-scrollable": this.props.scrollable,
             "resizeable-window-body-nonscrollable": !this.props.scrollable
         });
-        const style = { display: this.props.visible ? 'initial' : 'none' };
+        const style = {display: this.props.visible ? 'initial' : 'none'};
         const maximized = this.state.geometry.maximized ? true : false;
         const minimized = this.state.geometry.minimized ? true : false;
         const zIndex = 10 + this.props.windowStacking.findIndex(item => item === this.id);
@@ -174,7 +174,7 @@ class ResizeableWindow extends React.Component {
                 {this.props.onClose ? (<Icon className="resizeable-window-titlebar-control" icon="remove" onClick={this.onClose} titlemsgid={LocaleUtils.trmsg("window.close")} />) : null}
             </div>),
             (<div className={bodyclasses} key="body" onMouseDown={(ev) => { this.stopEvent(ev); this.props.raiseWindow(this.id); }} onMouseUp={this.stopEvent} onTouchStart={this.stopEvent}>
-                <div className="resizeable-window-drag-shield" ref={el => { this.dragShield = el; }} />
+                <div className="resizeable-window-drag-shield" ref={el => {this.dragShield = el;}} />
                 {this.renderRole("body")}
             </div>)
         ];
@@ -219,7 +219,7 @@ class ResizeableWindow extends React.Component {
                     onDragStop={this.onDragStop}
                     onMouseDown={() => this.props.raiseWindow(this.id)}
                     onResizeStop={this.onResizeStop}
-                    ref={c => { this.rnd = c; }} style={{ zIndex: zIndex }}>
+                    ref={c => { this.rnd = c; }} style={{zIndex: zIndex}}>
                     {content}
                 </Rnd>
             </div>
@@ -231,8 +231,8 @@ class ResizeableWindow extends React.Component {
         }
     }
     onDragStop = (ev, data) => {
-        const geometry = { ...this.state.geometry, x: data.x, y: data.y };
-        this.setState({ geometry: geometry });
+        const geometry = {...this.state.geometry, x: data.x, y: data.y};
+        this.setState({geometry: geometry});
         if (this.dragShield) {
             this.dragShield.style.display = 'none';
         }
@@ -245,21 +245,21 @@ class ResizeableWindow extends React.Component {
             width: this.state.geometry.width + delta.width,
             height: this.state.geometry.height + delta.height
         };
-        this.setState({ geometry: geometry });
+        this.setState({geometry: geometry});
     }
     toggleDock = () => {
         const geometry = {
             ...this.state.geometry,
             docked: !this.state.geometry.docked
         };
-        this.setState({ geometry: geometry });
+        this.setState({geometry: geometry});
     }
     toggleMinimize = () => {
         const geometry = {
             ...this.state.geometry,
             minimized: !this.state.geometry.minimized
         };
-        this.setState({ geometry: geometry });
+        this.setState({geometry: geometry});
     }
     toggleMaximize = () => {
         const geometry = {
@@ -267,7 +267,7 @@ class ResizeableWindow extends React.Component {
             maximized: !this.state.geometry.maximized,
             minimized: false
         };
-        this.setState({ geometry: geometry });
+        this.setState({geometry: geometry});
     }
 }
 

--- a/components/style/ResizeableWindow.css
+++ b/components/style/ResizeableWindow.css
@@ -36,6 +36,23 @@ div.resizeable-window-docked-left {
     bottom: initial!important;
 }
 
+div.resizeable-window-docked-right {
+    transform: none!important;
+    left: initial!important;
+    right: 0!important;
+    top: 0!important;
+    bottom: initial!important;
+}
+
+div.resizeable-window-docked-top {
+    transform: none!important;
+    left: 0!important;
+    right: 0!important;
+    top: 0!important;
+    bottom: initial!important;
+    width: initial!important;
+}
+
 div.resizeable-window-docked-bottom {
     transform: none!important;
     left: 0!important;

--- a/icons/dock_left.svg
+++ b/icons/dock_left.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   sodipodi:docname="dock.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="5.3033008"
+     inkscape:cy="6.629126"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     units="px"
+     inkscape:document-rotation="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4231"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.65)">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12,294.65 v -2 H 1 v 21 h 11 v -19 h -2 v 17 H 3 v -17 z"
+       id="path834"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.49031px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 23.912991,301.14964 -7.451604,0.01 -0.01935,-2.98067 L 12,302.62102 l 4.5,4.5 -0.01936,-2.9807 7.432349,0.01 z"
+       id="path836"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="2.7317833"
+       inkscape:transform-center-y="39.681852"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/icons/dock_right.svg
+++ b/icons/dock_right.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   sodipodi:docname="dock.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="5.3033008"
+     inkscape:cy="6.629126"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     units="px"
+     inkscape:document-rotation="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4231"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.65)">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12.429533,294.65 v -2 h 11 v 21 h -11 v -19 h 2 v 17 h 7 v -17 z"
+       id="path834"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.49031px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 0.51654926,301.14964 7.45160424,0.01 0.01935,-2.98067 4.4420295,4.44205 -4.4999925,4.5 0.01936,-2.9807 -7.43234924,0.01 z"
+       id="path836"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="-2.7317837"
+       inkscape:transform-center-y="39.681852"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/icons/dock_top.svg
+++ b/icons/dock_top.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   sodipodi:docname="dock_bottom.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="12.311234"
+     inkscape:cy="16.099306"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     units="px"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4231"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.65)">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3.956496,302.32986 h -2 v -11 h 21 v 11 h -19 v -2 h 17 v -7 h -17 z"
+       id="path834"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.49031px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 10.456136,314.24285 0.01,-7.4516 -2.98067,-0.0194 4.44205,-4.44204 4.5,4.5 -2.9807,-0.0194 0.01,7.43235 z"
+       id="path836"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="2.7317833"
+       inkscape:transform-center-y="-39.681848"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/icons/undock_left.svg
+++ b/icons/undock_left.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="undock.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="5.2542277"
+     inkscape:cy="6.5679421"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1051"
+     inkscape:window-x="1600"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     units="px"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4231"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.65)">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12,294.65 v -2 H 1 v 21 h 11 v -19 h -2 v 17 H 3 v -17 z"
+       id="path834"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.49031px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12,301.14964 7.451604,0.01 0.01935,-2.98067 4.442037,4.44205 -4.5,4.5 0.01936,-2.9807 -7.432349,0.01 z"
+       id="path836"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="-2.7317833"
+       inkscape:transform-center-y="39.681857"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/icons/undock_right.svg
+++ b/icons/undock_right.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   sodipodi:docname="dock_right.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="5.3033008"
+     inkscape:cy="6.629126"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     units="px"
+     inkscape:document-rotation="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4231"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.65)">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12.429533,294.65 v -2 h 11 v 21 h -11 v -19 h 2 v 17 h 7 v -17 z"
+       id="path834"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.49031px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12.418071,301.14964 -7.4516161,0.01 -0.01935,-2.98067 -4.4420288,4.44205 4.4999918,4.5 -0.01936,-2.9807 7.4323611,0.01 z"
+       id="path836"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="2.7317837"
+       inkscape:transform-center-y="39.681852"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>

--- a/icons/undock_top.svg
+++ b/icons/undock_top.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   sodipodi:docname="dock_top.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="12.437503"
+     inkscape:cy="16.541248"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     units="px"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4231"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.65)">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3.956496,302.32986 h -2 v -11 h 21 v 11 h -19 v -2 h 17 v -7 h -17 z"
+       id="path834"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.49031px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 10.456136,302.38794 0.01,7.4516 -2.98067,0.0194 4.44205,4.44204 4.5,-4.5 -2.9807,0.0194 0.01,-7.43235 z"
+       id="path836"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="2.7317833"
+       inkscape:transform-center-y="39.681852"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+</svg>


### PR DESCRIPTION
I needed it so maybe it's useful to someone else.

I'm thinking if it would be interesting to add an option to dock it to the full height, like it does when docking at the bottom but on the right/left too. 
I personally don't see why you'd want it to be resized when docked to the sides but not when docked to the bottom. If I wanted that I would just move it to the top-left corner of the map and leave it there, it would serve the same purpouse... To me if you dock it it should occupy all the space on that side.

I might be wrong so please, tell me what you think so we can implement this properly.
Thanks!