### PR TITLE
Identify: Use layer filters in GetFeatureInfo request

### DIFF
--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -99,7 +99,12 @@ class Identify extends React.Component {
             let queryableLayers = [];
             queryableLayers = IdentifyUtils.getQueryLayers(this.props.layers, this.props.map);
             queryableLayers.forEach(l => {
-                const request = IdentifyUtils.buildRequest(l, l.queryLayers.join(","), clickPoint, this.props.map, this.props.params);
+                const params = {...this.props.params};
+                // Apply layer filters to identify request
+                if (l.params.FILTER) {
+                    params.filter = l.params.FILTER
+                }
+                const request = IdentifyUtils.buildRequest(l, l.queryLayers.join(","), clickPoint, this.props.map, params);
                 ++pendingRequests;
                 IdentifyUtils.sendRequest(request, (response) => {
                     this.setState({pendingRequests: this.state.pendingRequests - 1});
@@ -169,7 +174,7 @@ class Identify extends React.Component {
             delete params.region_feature_count;
         }
         queryableLayers.forEach(layer => {
-            const request = IdentifyUtils.buildFilterRequest(layer, layer.queryLayers.join(","), filter, this.props.map, this.props.params);
+            const request = IdentifyUtils.buildFilterRequest(layer, layer.queryLayers.join(","), filter, this.props.map, params);
             ++pendingRequests;
             IdentifyUtils.sendRequest(request, (response) => {
                 this.setState({pendingRequests: this.state.pendingRequests - 1});

--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -99,12 +99,7 @@ class Identify extends React.Component {
             let queryableLayers = [];
             queryableLayers = IdentifyUtils.getQueryLayers(this.props.layers, this.props.map);
             queryableLayers.forEach(l => {
-                const params = {...this.props.params};
-                // Apply layer filters to identify request
-                if (l.params.FILTER) {
-                    params.filter = l.params.FILTER
-                }
-                const request = IdentifyUtils.buildRequest(l, l.queryLayers.join(","), clickPoint, this.props.map, params);
+                const request = IdentifyUtils.buildRequest(l, l.queryLayers.join(","), clickPoint, this.props.map, this.props.params);
                 ++pendingRequests;
                 IdentifyUtils.sendRequest(request, (response) => {
                     this.setState({pendingRequests: this.state.pendingRequests - 1});

--- a/utils/IdentifyUtils.js
+++ b/utils/IdentifyUtils.js
@@ -91,6 +91,9 @@ const IdentifyUtils = {
         if (CoordinatesUtils.getAxisOrder(map.projection).substr(0, 2) === 'ne' && version === '1.3.0') {
             bbox = [center[1] - dx, center[0] - dy, center[1] + dx, center[0] + dy];
         }
+        if (layer.params.FILTER) {
+            options.filter = layer.params.FILTER
+        }
         const params = {
             height: size[0],
             width: size[1],


### PR DESCRIPTION
Hi,

I thought the Identify tool should only return the features you can see, so it should have the same filters as the layers. Please let me know if this is not the correct way to do it.