### PR TITLE
themeBlacklist on menu items and toolbar items

### DIFF
--- a/components/AppMenu.jsx
+++ b/components/AppMenu.jsx
@@ -199,6 +199,9 @@ class AppMenu extends React.Component {
     renderMenuItems = (items, level, filter, path) => {
         if (items) {
             return items.map((item, idx) => {
+                if (item.themeBlacklist && (item.themeBlacklist.includes(this.props.currentTheme.title) || item.themeBlacklist.includes(this.props.currentTheme.name))) {
+                    return null
+                }
                 if (item.themeWhitelist && !(item.themeWhitelist.includes(this.props.currentTheme.title) || item.themeWhitelist.includes(this.props.currentTheme.name))) {
                     return null;
                 }

--- a/components/Toolbar.jsx
+++ b/components/Toolbar.jsx
@@ -44,6 +44,9 @@ class Toolbar extends React.Component {
         }
     }
     renderToolbarItem = (item) => {
+        if (item.themeBlacklist && (item.themeBlacklist.includes(this.props.currentTheme.title) || item.themeBlacklist.includes(this.props.currentTheme.name))) {
+            return null
+        }
         if (item.themeWhitelist && !(item.themeWhitelist.includes(this.props.currentTheme.title) || item.themeWhitelist.includes(this.props.currentTheme.name))) {
             return null;
         }


### PR DESCRIPTION
We added the ability to set a theme blacklist for menu items and toolbar items. It can coexist with the current theme whitelist.