### PR TITLE
More TimeManager improvements

### DIFF
--- a/plugins/TimeManager.jsx
+++ b/plugins/TimeManager.jsx
@@ -51,10 +51,10 @@ const DateUnitLabels = {
     "100y": LocaleUtils.trmsg("timemanager.unit.century")
 };
 
-const qgis_date_format = new Format({
+const qgisDateFormat = new Format({
     //        $dateExpr           $hour        $minute         $second             $millisecond                 $zone                 $offset
     matcher: /^(.*?)[\s,-]*([01]\d|2[0-3])\:([0-5]\d)(?:\:([0-5]\d|60)(?:[\.,](\d{9}|\d{6}|\d{1,3}))?)?[\s,-]*\(?(UTC)?[\s,-]*([+-]0\d?\:?(?:[0-5]\d)?)?[\s,-]*\)?$/i,
-    handler: function ([match, dateExpr, hour, minute, second, millisecond, zone, offset]) {
+    handler: function([match, dateExpr, hour, minute, second, millisecond, zone, offset]) {
         let result = {};
         if (dateExpr) {
             result = this.parser.attempt(dateExpr);
@@ -62,23 +62,23 @@ const qgis_date_format = new Format({
                 return result;
             }
         }
-        result["hour"] = hour;
-        result["minute"] = minute;
+        result.hour = hour;
+        result.minute = minute;
         if (second) {
-            result["second"] = second;
+            result.second = second;
         }
         if (millisecond && millisecond.length > 3) {
-            result["millisecond"] = millisecond.slice(0, 3);
+            result.millisecond = millisecond.slice(0, 3);
         } else if (millisecond) {
-            result["millisecond"] = millisecond;
+            result.millisecond = millisecond;
         }
         if (offset) {
-            result["offset"] = offset;
+            result.offset = offset;
         }
         return result;
-    },
+    }
 });
-dateParser.addFormat(qgis_date_format)
+dateParser.addFormat(qgisDateFormat);
 
 // QGIS server does not return any feature that does not have "startdate"/"enddate" set.
 // To workaround this limitation, a placeholder date is used to make features
@@ -104,14 +104,14 @@ class TimeManager extends React.Component {
         defaultAnimationInterval: PropTypes.number,
         /** Default for TimeManager enabled when loading application. `true` or `false` */
         defaultEnabled: PropTypes.bool,
+        /** The default number of features that will be requested. */
+        defaultFeatureCount: PropTypes.number,
         /** The default step size for the temporal animation, in step units. */
         defaultStepSize: PropTypes.number,
         /** The default step unit for the temporal animation, one of `ms`, `s`, `m`, `d`, `M`, `y`, `10y`, `100y` */
         defaultStepUnit: PropTypes.string,
         /** The default timeline display mode. One of `hidden`, `minimal`, `features`, `layers`. */
         defaultTimelineDisplay: PropTypes.string,
-        /** The default number of features that will be requested. */
-        defaultFeatureCount: PropTypes.number,
         /** The default timeline mode. One of `fixed`, `infinite`. */
         defaultTimelineMode: PropTypes.string,
         layerVisibilities: PropTypes.object,

--- a/plugins/TimeManager.jsx
+++ b/plugins/TimeManager.jsx
@@ -102,6 +102,8 @@ class TimeManager extends React.Component {
         dateFormat: PropTypes.string,
         /** The default interval for the temporal animation, in seconds. */
         defaultAnimationInterval: PropTypes.number,
+        /** Default for TimeManager enabled when loading application. `true` or `false` */
+        defaultEnabled: PropTypes.bool,
         /** The default step size for the temporal animation, in step units. */
         defaultStepSize: PropTypes.number,
         /** The default step unit for the temporal animation, one of `ms`, `s`, `m`, `d`, `M`, `y`, `10y`, `100y` */
@@ -133,6 +135,7 @@ class TimeManager extends React.Component {
         cursorFormat: "datetime",
         dateFormat: "YYYY-MM-DD[\n]HH:mm:ss",
         defaultAnimationInterval: 1,
+        defaultEnabled: false,
         defaultStepSize: 1,
         defaultStepUnit: "d",
         defaultFeatureCount: 100,
@@ -178,6 +181,8 @@ class TimeManager extends React.Component {
         this.updateMapMarkersTimeout = null;
         TimeManager.defaultState.stepSize = props.defaultStepSize;
         TimeManager.defaultState.stepSizeUnit = props.defaultStepUnit;
+        TimeManager.defaultState.timelineDisplay = props.defaultTimelineDisplay;
+        TimeManager.defaultState.timeEnabled = props.defaultEnabled;
         if (!props.stepUnits.includes(TimeManager.defaultState.stepSizeUnit)) {
             TimeManager.defaultState.stepSizeUnit = props.stepUnits[0];
         }

--- a/plugins/TimeManager.jsx
+++ b/plugins/TimeManager.jsx
@@ -159,13 +159,14 @@ class TimeManager extends React.Component {
         dialogWidth: 0,
         markersEnabled: false,
         markersCanBeEnabled: true,
-        timelineDisplay: true,
+        timelineDisplay: 'features',
         featureCount: 100,
         timelineMode: 'continuous',
         timeData: {
             layerDimensions: {},
             values: [],
-            attributes: {}
+            attributes: {},
+            layers: []
         },
         timeFeatures: null,
         settingsPopup: false,

--- a/scripts/themesConfig.js
+++ b/scripts/themesConfig.js
@@ -230,7 +230,9 @@ function getLayerTree(layer, resultLayers, visibleLayers, printLayers, level, co
                 units: dim.$.units,
                 name: dim.$.name,
                 multiple: dim.$.multipleValues === "1",
-                value: dim._
+                value: dim._,
+                fieldName: dim.$.fieldName,
+                endFieldName: dim.$.endFieldName
             });
         });
 

--- a/scripts/themesConfig.py
+++ b/scripts/themesConfig.py
@@ -256,7 +256,9 @@ def getLayerTree(layer, resultLayers, visibleLayers, printLayers, level, collaps
                 "units": dim.getAttribute("units"),
                 "name": dim.getAttribute("name"),
                 "multiple": dim.getAttribute("multipleValues") == "1",
-                "value": getElementValue(dim)
+                "value": getElementValue(dim),
+                "fieldName": dim.getAttribute("fieldName"),
+                "endFieldName": dim.getAttribute("endFieldName")
             })
 
     else:


### PR DESCRIPTION
Hi,

I have tried to enable TimeManager by default with a new props in this PR. Also I wanted to set the plugin visible at the start of the application by setting `startupTask` in `config.json`.

I have used http://qwc2.sourcepole.ch/ows/observations for my tests and application crashed as there are some NULL values in `enddate` and `startdate` in some data.

I have also added a dummy value to handle start date. (ping @danceb)

