### PR TITLE
StandardApp: wait themes are loaded before to set startupTask

### DIFF
--- a/components/StandardApp.jsx
+++ b/components/StandardApp.jsx
@@ -150,12 +150,12 @@ class AppInitComponent extends React.Component {
                     }
                 }
             });
+            const task = ConfigUtils.getConfigProp("startupTask");
+            if (task) {
+                const mapClickAction = ConfigUtils.getPluginConfig(task.key).mapClickAction;
+                this.props.setCurrentTask(task.key, task.mode, mapClickAction);
+            }
         });
-        const task = ConfigUtils.getConfigProp("startupTask");
-        if (task) {
-            const mapClickAction = ConfigUtils.getPluginConfig(task.key).mapClickAction;
-            this.props.setCurrentTask(task.key, task.mode, mapClickAction);
-        }
     };
     render() {
         return null;


### PR DESCRIPTION
Hi @manisandro 

I have forgotten something in previous PR #237 

`currenttimestamp` could be at null if TimeManager is enabled by default and application crashes, so I propose here to set initial value to `Date.now()`.

Thanks