### PR TITLE
Clickable empty space in MapInfoTooltip

### DIFF
--- a/plugins/style/MapInfoTooltip.css
+++ b/plugins/style/MapInfoTooltip.css
@@ -1,6 +1,7 @@
 div.mapinfotooltip {
     position: absolute;
     z-index: 2;
+    pointer-events: none;
 }
 
 div.mapinfotooltip-window {
@@ -11,6 +12,7 @@ div.mapinfotooltip-window {
     transform: translate(-50%, 0);
     -webkit-font-smoothing: antialiased;
     white-space: nowrap;
+    pointer-events: all;
 }
 
 div.mapinfotooltip-titlebar {


### PR DESCRIPTION
The top division of the MapInfoTooltip is clickable. This is an issue as the interactive widget is offset (as shown in the image), and right-clicking on the invisible top division is not registered as a map interaction.

To fix the issue we disable all pointer events on the top division and reenable them on the visible division.

![image](https://github.com/qgis/qwc2/assets/18171867/58c66821-2787-49e5-abef-495a59028dc7)
