### PR TITLE
Add format and requestEncoding parameters in WMTS config generator

### DIFF
--- a/scripts/wmts_config_generator.py
+++ b/scripts/wmts_config_generator.py
@@ -123,10 +123,25 @@ if wgs84BoundingBox is not None:
     upperCorner = list(map(float, filter(bool, getFirstElementValueByTagName(wgs84BoundingBox,"ows:UpperCorner").split(" "))))
     bounds = lowerCorner + upperCorner
 
+# Format
+format = getFirstElementValueByTagName(targetLayer, "Format")
+
+# RequestEncoding
+requestEncoding = ""
+operationsMetadata = getFirstElementByTagName(capabilities, "ows:OperationsMetadata")
+if operationsMetadata is not None:
+    for operation in operationsMetadata.getElementsByTagName("ows:Operation"):
+        if operation.getAttribute("name") == "GetCapabilities":
+            constraint = getFirstElementByTagName(operation, "ows:Constraint")
+            if constraint.getAttribute("name") == "GetEncoding":
+                requestEncoding = getFirstElementValueByTagName(constraint, "ows:Value")
+
 result = {
     "type": "wmts",
     "url": tileUrl,
     "name": layerName,
+    "format": format,
+    "requestEncoding": requestEncoding,
     "tileMatrixPrefix": "",
     "tileMatrixSet": tileMatrixName,
     "originX": origin[0],


### PR DESCRIPTION
Hi,

WMTS capabilities contain `format` and `requestencoding` parameters that are used to create our WMTS background layer configuration in `themesConfig`.

This PR adds these parameters in the output of `wmts_config_generator` script, as it was done in https://github.com/qwc-services/qwc-admin-gui/pull/45 some time ago.

Thanks