### PR TITLE
Style marker and edit

### DIFF
--- a/plugins/map/EditingSupport.jsx
+++ b/plugins/map/EditingSupport.jsx
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import ol from 'openlayers';
 import {setEditContext} from '../../actions/editing';
+import FeatureStyles from '../../utils/FeatureStyles';
 
 class EditingSupport extends React.Component {
     static propTypes = {
@@ -24,38 +25,23 @@ class EditingSupport extends React.Component {
         this.interaction = null;
         this.layer = null;
         this.currentFeature = null;
-        this.editStyle = [
-            new ol.style.Style({
-                fill: new ol.style.Fill({ color: [255, 0, 0, 0.5] }),
-                stroke: new ol.style.Stroke({ color: 'red', width: 2})
-            }),
-            new ol.style.Style({
-                image: new ol.style.RegularShape({
-                    fill: new ol.style.Fill({color: 'white'}),
-                    stroke: new ol.style.Stroke({color: 'red', width: 2}),
-                    points: 4,
-                    radius: 5,
-                    angle: Math.PI / 4
-                }),
-                geometry: (feature) => {
-                    if (feature.getGeometry().getType() === "Point") {
-                        return new ol.geom.MultiPoint([feature.getGeometry().getCoordinates()]);
-                    } else if (feature.getGeometry().getType() === "LineString") {
-                        return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates());
-                    } else if (feature.getGeometry().getType() === "Polygon") {
-                        return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates()[0]);
-                    } else if (feature.getGeometry().getType() === "MultiPoint") {
-                        return feature.getGeometry();
-                    } else if (feature.getGeometry().getType() === "MultiLineString") {
-                        return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates()[0]);
-                    } else if (feature.getGeometry().getType() === "MultiPolygon") {
-                        return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates()[0][0]);
-                    } else {
-                        return feature.getGeometry();
-                    }
-                }
-            })
-        ];
+        this.editStyle = FeatureStyles.interaction();
+        this.editStyle[1].setGeometry((feature) => {
+            if (feature.getGeometry().getType() === "Point") {
+                return new ol.geom.MultiPoint([feature.getGeometry().getCoordinates()]);
+            } else if (feature.getGeometry().getType() === "LineString") {
+                return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates());
+            } else if (feature.getGeometry().getType() === "Polygon") {
+                return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates()[0]);
+            } else if (feature.getGeometry().getType() === "MultiPoint") {
+                return feature.getGeometry();
+            } else if (feature.getGeometry().getType() === "MultiLineString") {
+                return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates()[0]);
+            } else if (feature.getGeometry().getType() === "MultiPolygon") {
+                return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates()[0][0]);
+            }
+            return feature.getGeometry();
+        });
     }
     componentDidUpdate(prevProps) {
         if (this.props.editContext === prevProps.editContext) {

--- a/plugins/map/EditingSupport.jsx
+++ b/plugins/map/EditingSupport.jsx
@@ -11,8 +11,7 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import ol from 'openlayers';
 import {setEditContext} from '../../actions/editing';
-import FeatureStyles from '../../utils/FeatureStyles';
-import featureStyles from "../../utils/FeatureStyles";
+import FeatureStyles from "../../utils/FeatureStyles";
 
 class EditingSupport extends React.Component {
     static propTypes = {
@@ -26,8 +25,7 @@ class EditingSupport extends React.Component {
         this.interaction = null;
         this.layer = null;
         this.currentFeature = null;
-        this.editStyle = FeatureStyles.interaction();
-        this.editStyle[1].setGeometry((feature) => {
+        const geometryFunction = (feature) => {
             if (feature.getGeometry().getType() === "Point") {
                 return new ol.geom.MultiPoint([feature.getGeometry().getCoordinates()]);
             } else if (feature.getGeometry().getType() === "LineString") {
@@ -42,7 +40,11 @@ class EditingSupport extends React.Component {
                 return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates()[0][0]);
             }
             return feature.getGeometry();
-        });
+        };
+        this.editStyle = [
+            FeatureStyles.interaction(),
+            FeatureStyles.interactionVertex({geometryFunction})
+        ];
     }
     componentDidUpdate(prevProps) {
         if (this.props.editContext === prevProps.editContext) {
@@ -114,7 +116,7 @@ class EditingSupport extends React.Component {
                 }
                 return ol.events.condition.shiftKeyOnly(event) && ol.events.condition.singleClick(event);
             },
-            style: featureStyles.sketchInteraction(),
+            style: FeatureStyles.sketchInteraction(),
         });
         modifyInteraction.on('modifyend', () => {
             this.commitCurrentFeature();

--- a/plugins/map/EditingSupport.jsx
+++ b/plugins/map/EditingSupport.jsx
@@ -12,6 +12,7 @@ import {connect} from 'react-redux';
 import ol from 'openlayers';
 import {setEditContext} from '../../actions/editing';
 import FeatureStyles from '../../utils/FeatureStyles';
+import featureStyles from "../../utils/FeatureStyles";
 
 class EditingSupport extends React.Component {
     static propTypes = {
@@ -112,7 +113,8 @@ class EditingSupport extends React.Component {
                     this.props.map.setIgnoreNextClick(true);
                 }
                 return ol.events.condition.shiftKeyOnly(event) && ol.events.condition.singleClick(event);
-            }
+            },
+            style: featureStyles.sketchInteraction(),
         });
         modifyInteraction.on('modifyend', () => {
             this.commitCurrentFeature();

--- a/plugins/map/MeasurementSupport.jsx
+++ b/plugins/map/MeasurementSupport.jsx
@@ -167,16 +167,18 @@ class MeasurementSupport extends React.Component {
         });
     };
     featureStyleFunction = (feature) => {
-        const styles = FeatureStyles.measureInteraction(feature);
-        styles[1].setGeometry((f) => {
+        const geometryFunction = (f) => {
             if (f.getGeometry().getType() === "Point") {
                 return new ol.geom.MultiPoint([f.getGeometry().getCoordinates()]);
             } else if (f.getGeometry().getType() === "LineString") {
                 return new ol.geom.MultiPoint(f.getGeometry().getCoordinates());
             }
             return new ol.geom.MultiPoint(f.getGeometry().getCoordinates()[0]);
-        });
-        return styles;
+        };
+        return [
+            ...FeatureStyles.measureInteraction(feature),
+            FeatureStyles.measureInteractionVertex({geometryFunction})
+        ];
     };
 }
 

--- a/plugins/map/RedliningPickSupport.jsx
+++ b/plugins/map/RedliningPickSupport.jsx
@@ -12,7 +12,7 @@ import {connect} from 'react-redux';
 import isEmpty from 'lodash.isempty';
 import ol from 'openlayers';
 import {changeRedliningPickState} from '../../actions/redliningPick';
-import featureStyles from "../../utils/FeatureStyles";
+import FeatureStyles from "../../utils/FeatureStyles";
 
 class RedliningPickSupport extends React.Component {
     static propTypes = {
@@ -26,15 +26,15 @@ class RedliningPickSupport extends React.Component {
 
         this.interactions = [];
         this.selectedFeatures = [];
-        this.selectedStyle = featureStyles.interaction()[1];
-        this.selectedStyle.setGeometry((feature) => {
+        const geometryFunction = (feature) => {
             if (feature.getGeometry().getType() === "Point") {
                 return new ol.geom.MultiPoint([f.getGeometry().getCoordinates()]);
             } else if (feature.getGeometry().getType() === "LineString") {
                 return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates());
             }
             return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates()[0]);
-        });
+        }
+        this.selectedStyle = FeatureStyles.interactionVertex({geometryFunction});
     }
     componentDidUpdate(prevProps) {
         if (this.props.redliningPick === prevProps.redliningPick) {

--- a/plugins/map/RedliningPickSupport.jsx
+++ b/plugins/map/RedliningPickSupport.jsx
@@ -12,6 +12,7 @@ import {connect} from 'react-redux';
 import isEmpty from 'lodash.isempty';
 import ol from 'openlayers';
 import {changeRedliningPickState} from '../../actions/redliningPick';
+import featureStyles from "../../utils/FeatureStyles";
 
 class RedliningPickSupport extends React.Component {
     static propTypes = {
@@ -25,23 +26,14 @@ class RedliningPickSupport extends React.Component {
 
         this.interactions = [];
         this.selectedFeatures = [];
-        this.selectedStyle = new ol.style.Style({
-            image: new ol.style.RegularShape({
-                fill: new ol.style.Fill({color: 'white'}),
-                stroke: new ol.style.Stroke({color: 'red', width: 2}),
-                points: 4,
-                radius: 5,
-                angle: Math.PI / 4
-            }),
-            geometry: (f) => {
-                if (f.getGeometry().getType() === "Point") {
-                    return new ol.geom.MultiPoint([f.getGeometry().getCoordinates()]);
-                } else if (f.getGeometry().getType() === "LineString") {
-                    return new ol.geom.MultiPoint(f.getGeometry().getCoordinates());
-                } else {
-                    return new ol.geom.MultiPoint(f.getGeometry().getCoordinates()[0]);
-                }
+        this.selectedStyle = featureStyles.interaction()[1];
+        this.selectedStyle.setGeometry((feature) => {
+            if (feature.getGeometry().getType() === "Point") {
+                return new ol.geom.MultiPoint([f.getGeometry().getCoordinates()]);
+            } else if (feature.getGeometry().getType() === "LineString") {
+                return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates());
             }
+            return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates()[0]);
         });
     }
     componentDidUpdate(prevProps) {

--- a/plugins/map/RedliningSupport.jsx
+++ b/plugins/map/RedliningSupport.jsx
@@ -21,14 +21,6 @@ import FeatureStyles from '../../utils/FeatureStyles';
 import MeasureUtils from '../../utils/MeasureUtils';
 import SnapInteraction from './SnapInteraction';
 
-const DrawStyle = new ol.style.Style({
-    image: new ol.style.Circle({
-        fill: new ol.style.Fill({color: '#0099FF'}),
-        stroke: new ol.style.Stroke({color: '#FFFFFF', width: 1.5}),
-        radius: 6
-    })
-});
-
 const GeomTypeConfig = {
     Text: {drawInteraction: (opts) => new ol.interaction.Draw({...opts, type: "Point"}), editTool: 'Pick', drawNodes: true},
     Point: {drawInteraction: (opts) => new ol.interaction.Draw({...opts, type: "Point"}), editTool: 'Pick', drawNodes: true},
@@ -71,27 +63,19 @@ class RedliningSupport extends React.Component {
                 stroke: new ol.style.Stroke({color: [0, 0, 0, 0.5], width: 4})
             })
         });
-        this.selectedStyle = new ol.style.Style({
-            image: new ol.style.RegularShape({
-                fill: new ol.style.Fill({color: 'white'}),
-                stroke: new ol.style.Stroke({color: 'red', width: 2}),
-                points: 4,
-                radius: 5,
-                angle: Math.PI / 4
-            }),
-            geometry: (f) => {
-                if (f.getGeometry().getType() === "Point") {
-                    return new ol.geom.MultiPoint([f.getGeometry().getCoordinates()]);
-                } else if (f.getGeometry().getType() === "LineString") {
-                    return new ol.geom.MultiPoint(f.getGeometry().getCoordinates());
-                } else if (f.getGeometry().getType() === "Polygon") {
-                    return new ol.geom.MultiPoint(f.getGeometry().getCoordinates()[0]);
-                } else if (f.getGeometry().getType() === "Circle") {
-                    const center = f.getGeometry().getCenter();
-                    return new ol.geom.MultiPoint([center, [center[0] + f.getGeometry().getRadius(), center[1]]]);
-                }
-                return null;
+        this.selectedStyle = FeatureStyles.interaction()[1];
+        this.selectedStyle.setGeometry((feature) => {
+            if (feature.getGeometry().getType() === "Point") {
+                return new ol.geom.MultiPoint([feature.getGeometry().getCoordinates()]);
+            } else if (feature.getGeometry().getType() === "LineString") {
+                return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates());
+            } else if (feature.getGeometry().getType() === "Polygon") {
+                return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates()[0]);
+            } else if (feature.getGeometry().getType() === "Circle") {
+                const center = feature.getGeometry().getCenter();
+                return new ol.geom.MultiPoint([center, [center[0] + feature.getGeometry().getRadius(), center[1]]]);
             }
+            return null;
         });
     }
     componentDidUpdate(prevProps) {
@@ -224,7 +208,7 @@ class RedliningSupport extends React.Component {
         const drawInteraction = geomTypeConfig.drawInteraction({
             stopClick: true,
             condition: (event) => { return event.originalEvent.buttons === 1; },
-            style: () => { return this.picking ? [] : DrawStyle; },
+            style: () => { return this.picking ? [] : FeatureStyles.sketchInteraction(); },
             freehand: isFreeHand
         });
         drawInteraction.on('drawstart', (evt) => {

--- a/plugins/map/RedliningSupport.jsx
+++ b/plugins/map/RedliningSupport.jsx
@@ -310,7 +310,8 @@ class RedliningSupport extends React.Component {
                         this.props.map.setIgnoreNextClick(true);
                     }
                     return ol.events.condition.shiftKeyOnly(event) && ol.events.condition.singleClick(event);
-                }
+                },
+                style: FeatureStyles.sketchInteraction(),
             });
             modifyInteraction.on('modifyend', () => {
                 this.props.changeRedliningState({selectedFeature: this.currentFeatureObject()});

--- a/plugins/map/RedliningSupport.jsx
+++ b/plugins/map/RedliningSupport.jsx
@@ -63,8 +63,7 @@ class RedliningSupport extends React.Component {
                 stroke: new ol.style.Stroke({color: [0, 0, 0, 0.5], width: 4})
             })
         });
-        this.selectedStyle = FeatureStyles.interaction()[1];
-        this.selectedStyle.setGeometry((feature) => {
+        const geometryFunction = (feature) => {
             if (feature.getGeometry().getType() === "Point") {
                 return new ol.geom.MultiPoint([feature.getGeometry().getCoordinates()]);
             } else if (feature.getGeometry().getType() === "LineString") {
@@ -76,7 +75,8 @@ class RedliningSupport extends React.Component {
                 return new ol.geom.MultiPoint([center, [center[0] + feature.getGeometry().getRadius(), center[1]]]);
             }
             return null;
-        });
+        };
+        this.selectedStyle = FeatureStyles.interactionVertex({geometryFunction});
     }
     componentDidUpdate(prevProps) {
         const layerChanged = this.props.redlining.layer !== prevProps.redlining.layer;

--- a/plugins/map/SnapSupport.jsx
+++ b/plugins/map/SnapSupport.jsx
@@ -14,6 +14,7 @@ import ol from 'openlayers';
 import {v4 as uuidv4} from 'uuid';
 import {LayerRole} from '../../actions/layers';
 import IdentifyUtils from '../../utils/IdentifyUtils';
+import FeatureStyles from "../../utils/FeatureStyles";
 
 class SnapSupport extends React.Component {
     static propTypes = {
@@ -26,30 +27,15 @@ class SnapSupport extends React.Component {
     constructor(props) {
         super(props);
 
-        const snapStyle = [
-            new ol.style.Style({
-                fill: new ol.style.Fill({ color: [255, 255, 255, 0.05] }),
-                stroke: new ol.style.Stroke({ color: '#3399CC', width: 1})
-            }),
-            new ol.style.Style({
-                image: new ol.style.RegularShape({
-                    fill: new ol.style.Fill({ color: [255, 255, 255, 0.05] }),
-                    stroke: new ol.style.Stroke({color: '#3399CC', width: 1}),
-                    points: 4,
-                    radius: 5,
-                    angle: Math.PI / 4
-                }),
-                geometry: (feature) => {
-                    if (feature.getGeometry().getType() === "Point") {
-                        return new ol.geom.MultiPoint([feature.getGeometry().getCoordinates()]);
-                    } else if (feature.getGeometry().getType() === "LineString") {
-                        return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates());
-                    } else {
-                        return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates()[0]);
-                    }
-                }
-            })
-        ];
+        const snapStyle = FeatureStyles.interaction({}, true);
+        snapStyle[1].setGeometry((feature) => {
+            if (feature.getGeometry().getType() === "Point") {
+                return new ol.geom.MultiPoint([feature.getGeometry().getCoordinates()]);
+            } else if (feature.getGeometry().getType() === "LineString") {
+                return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates());
+            }
+            return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates()[0]);
+        })
         this.snapSource = new ol.source.Vector();
         this.snapLayer = new ol.layer.Vector({
             source: this.snapSource,

--- a/plugins/map/SnapSupport.jsx
+++ b/plugins/map/SnapSupport.jsx
@@ -26,21 +26,22 @@ class SnapSupport extends React.Component {
     };
     constructor(props) {
         super(props);
-
-        const snapStyle = FeatureStyles.interaction({}, true);
-        snapStyle[1].setGeometry((feature) => {
+        const geometryFunction = (feature) => {
             if (feature.getGeometry().getType() === "Point") {
                 return new ol.geom.MultiPoint([feature.getGeometry().getCoordinates()]);
             } else if (feature.getGeometry().getType() === "LineString") {
                 return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates());
             }
             return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates()[0]);
-        })
+        };
         this.snapSource = new ol.source.Vector();
         this.snapLayer = new ol.layer.Vector({
             source: this.snapSource,
             zIndex: 1000000,
-            style: snapStyle
+            style: [
+                FeatureStyles.interaction( {}, true),
+                FeatureStyles.interactionVertex({geometryFunction}, true),
+            ],
         });
         this.props.map.addLayer(this.snapLayer);
         this.curPos = null;

--- a/utils/FeatureStyles.js
+++ b/utils/FeatureStyles.js
@@ -21,6 +21,17 @@ const DEFAULT_FEATURE_STYLE = {
     textFont: "11pt sans-serif"
 };
 
+const DEFAULT_MARKER_STYLE = {
+    iconAnchor: [0.5, 1],
+    opacity: 1,
+    iconSrc: markerIcon,
+    color: undefined,
+    scale: undefined,
+    crossOrigin: undefined,
+    textColor: '#000000',
+    textStroke: '#FFFFFF',
+}
+
 export default {
     default: (feature, options) => {
         const opts = {...DEFAULT_FEATURE_STYLE, ...ConfigUtils.getConfigProp("defaultFeatureStyle"), ...options};
@@ -95,21 +106,25 @@ export default {
         return styles;
     },
     marker: (feature, options) => {
+        const opts = {...DEFAULT_MARKER_STYLE, ...ConfigUtils.getConfigProp("defaultMarkerStyle"), ...options};
         return [
             new ol.style.Style({
                 image: new ol.style.Icon({
-                    anchor: options.iconAnchor || [0.5, 1],
+                    anchor: opts.iconAnchor,
                     anchorXUnits: 'fraction',
                     anchorYUnits: 'fraction',
-                    opacity: 1,
-                    src: options.iconSrc || markerIcon
+                    opacity: opts.opacity,
+                    crossOrigin: opts.crossOrigin,
+                    src: opts.iconSrc,
+                    scale: opts.scale,
+                    color: opts.color,
                 }),
                 text: new ol.style.Text({
-                    font: '11pt sans-serif',
+                    font: opts.textFont || '11pt sans-serif',
                     text: feature.getProperties().label || "",
                     offsetY: 8,
-                    fill: new ol.style.Fill({color: '#000000'}),
-                    stroke: new ol.style.Stroke({color: '#FFFFFF', width: 3})
+                    fill: new ol.style.Fill({color: opts.textColor}),
+                    stroke: new ol.style.Stroke({color: opts.textStroke, width: 3})
                 })
             })
         ];

--- a/utils/FeatureStyles.js
+++ b/utils/FeatureStyles.js
@@ -46,9 +46,9 @@ const DEFAULT_INTERACTION_STYLE = {
     measureFillColor: [255, 0, 0, 0.25],
     measureStrokeColor: "red",
     measureStrokeWidth: 4,
-    measurePointFillColor: "white",
-    measurePointStrokeColor: "red",
-    measurePointStrokeWidth: 2,
+    measureVertexFillColor: "white",
+    measureVertexStrokeColor: "red",
+    measureVertexStrokeWidth: 2,
     measurePointRadius: 6,
     sketchPointFillColor: "#0099FF",
     sketchPointStrokeColor: "white",
@@ -159,30 +159,36 @@ export default {
         let fillColor = opts.fillColor;
         let strokeColor = opts.strokeColor;
         let strokeWidth = opts.strokeWidth;
-        let vertexFill = opts.vertexFillColor;
-        let vertexStroke = opts.vertexStrokeColor;
         if (isSnap) {
             fillColor = opts.snapFillColor;
             strokeColor = opts.snapStrokeColor;
-            strokeWidth = opts.SnapStrokeWidth;
+            strokeWidth = opts.snapStrokeWidth;
+        }
+        return new ol.style.Style({
+            fill: new ol.style.Fill({ color: fillColor }),
+            stroke: new ol.style.Stroke({ color: strokeColor, width: strokeWidth})
+        });
+    },
+    interactionVertex: (options, isSnap) => {
+        const opts = {...DEFAULT_INTERACTION_STYLE, ...ConfigUtils.getConfigProp("defaultInteractionStyle"), ...options};
+        let strokeWidth = opts.strokeWidth;
+        let vertexFill = opts.vertexFillColor;
+        let vertexStroke = opts.vertexStrokeColor;
+        if (isSnap) {
+            strokeWidth = opts.snapStrokeWidth;
             vertexFill = opts.snapVertexFillColor;
             vertexStroke = opts.snapVertexStrokeColor;
         }
-        return [
-            new ol.style.Style({
-                fill: new ol.style.Fill({ color: fillColor }),
-                stroke: new ol.style.Stroke({ color: strokeColor, width: strokeWidth})
+        return new ol.style.Style({
+            image: new ol.style.RegularShape({
+                fill: new ol.style.Fill({ color: vertexFill }),
+                stroke: new ol.style.Stroke({ color: vertexStroke, width: strokeWidth }),
+                points: 4,
+                radius: 5,
+                angle: Math.PI / 4
             }),
-            new ol.style.Style({
-                image: new ol.style.RegularShape({
-                    fill: new ol.style.Fill({ color: vertexFill }),
-                    stroke: new ol.style.Stroke({ color: vertexStroke, width: strokeWidth }),
-                    points: 4,
-                    radius: 5,
-                    angle: Math.PI / 4
-                }),
-            })
-        ]
+            geometry: opts.geometryFunction,
+        });
     },
     measureInteraction: (feature, options) => {
         const opts = {...DEFAULT_INTERACTION_STYLE, ...ConfigUtils.getConfigProp("defaultInteractionStyle"), ...options};
@@ -192,18 +198,18 @@ export default {
             fillColor: opts.measureFillColor,
             strokeDash: []
         };
-        return [
-            // Base geometry
-            ...defaultStyle(feature, styleOptions),
-            // Points
-            new ol.style.Style({
-                image: new ol.style.Circle({
-                    radius: opts.measurePointRadius,
-                    fill: new ol.style.Fill({color: opts.measurePointFillColor}),
-                    stroke: new ol.style.Stroke({ color: opts.measurePointStrokeColor, width: opts.measurePointStrokeWidth })
-                }),
-            })
-        ]
+        return defaultStyle(feature, styleOptions);
+    },
+    measureInteractionVertex: (options) => {
+        const opts = {...DEFAULT_INTERACTION_STYLE, ...ConfigUtils.getConfigProp("defaultInteractionStyle"), ...options};
+        return new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: opts.measurePointRadius,
+                fill: new ol.style.Fill({color: opts.measureVertexFillColor}),
+                stroke: new ol.style.Stroke({ color: opts.measureVertexStrokeColor, width: opts.measureVertexStrokeWidth })
+            }),
+            geometry: opts.geometryFunction,
+        });
     },
     sketchInteraction: (options) => {
         const opts = {...DEFAULT_INTERACTION_STYLE, ...ConfigUtils.getConfigProp("defaultInteractionStyle"), ...options};

--- a/utils/FeatureStyles.js
+++ b/utils/FeatureStyles.js
@@ -32,79 +32,104 @@ const DEFAULT_MARKER_STYLE = {
     textStroke: '#FFFFFF',
 }
 
-export default {
-    default: (feature, options) => {
-        const opts = {...DEFAULT_FEATURE_STYLE, ...ConfigUtils.getConfigProp("defaultFeatureStyle"), ...options};
-        const styles = [];
+const DEFAULT_INTERACTION_STYLE = {
+    fillColor: [255, 0, 0, 0.5],
+    strokeColor: "red",
+    strokeWidth: 1.5,
+    vertexFillColor: "white",
+    vertexStrokeColor: "red",
+    snapFillColor: [255, 255, 255, 0.05],
+    snapStrokeColor: '#3399CC',
+    snapStrokeWidth: 1,
+    snapVertexFillColor: [255, 255, 255, 0.05],
+    snapVertexStrokeColor: '#3399CC',
+    measureFillColor: [255, 0, 0, 0.25],
+    measureStrokeColor: "red",
+    measureStrokeWidth: 4,
+    measurePointFillColor: "white",
+    measurePointStrokeColor: "red",
+    measurePointStrokeWidth: 2,
+    measurePointRadius: 6,
+    sketchPointFillColor: "#0099FF",
+    sketchPointStrokeColor: "white",
+    sketchPointRadius: 6,
+}
+
+const defaultStyle = (feature, options) => {
+    const opts = {...DEFAULT_FEATURE_STYLE, ...ConfigUtils.getConfigProp("defaultFeatureStyle"), ...options};
+    const styles = [];
+    styles.push(
+        new ol.style.Style({
+            fill: new ol.style.Fill({
+                color: opts.fillColor
+            }),
+            stroke: new ol.style.Stroke({
+                color: opts.strokeColor,
+                width: opts.strokeWidth,
+                lineDash: opts.strokeDash
+            }),
+            image: opts.circleRadius > 0 ? new ol.style.Circle({
+                radius: opts.circleRadius,
+                fill: new ol.style.Fill({ color: opts.fillColor }),
+                stroke: new ol.style.Stroke({color: opts.strokeColor, width: opts.strokeWidth})
+            }) : null
+        })
+    );
+    if (feature.getProperties().label) {
         styles.push(
             new ol.style.Style({
-                fill: new ol.style.Fill({
-                    color: opts.fillColor
-                }),
-                stroke: new ol.style.Stroke({
-                    color: opts.strokeColor,
-                    width: opts.strokeWidth,
-                    lineDash: opts.strokeDash
-                }),
-                image: opts.circleRadius > 0 ? new ol.style.Circle({
-                    radius: opts.circleRadius,
-                    fill: new ol.style.Fill({ color: opts.fillColor }),
-                    stroke: new ol.style.Stroke({color: opts.strokeColor, width: opts.strokeWidth})
-                }) : null
+                geometry: (f) => {
+                    if (f.getGeometry().getType().startsWith("Multi")) {
+                        // Only label middle point
+                        const extent = f.getGeometry().getExtent();
+                        return new ol.geom.Point(f.getGeometry().getClosestPoint(ol.extent.getCenter(extent)));
+                    }
+                    return f.getGeometry();
+                },
+                text: new ol.style.Text({
+                    font: opts.textFont || '11pt sans-serif',
+                    text: feature.getProperties().label || "",
+                    overflow: true,
+                    fill: new ol.style.Fill({color: opts.textFill}),
+                    stroke: new ol.style.Stroke({color: opts.textStroke, width: 3}),
+                    textAlign: feature.getGeometry().getType() === "Point" ? 'left' : 'center',
+                    textBaseline: feature.getGeometry().getType() === "Point" ? 'bottom' : 'middle',
+                    offsetX: feature.getGeometry().getType() === "Point" ? (5 + opts.circleRadius) : 0
+                })
             })
         );
-        if (feature.getProperties().label) {
-            styles.push(
-                new ol.style.Style({
-                    geometry: (f) => {
-                        if (f.getGeometry().getType().startsWith("Multi")) {
-                            // Only label middle point
-                            const extent = f.getGeometry().getExtent();
-                            return new ol.geom.Point(f.getGeometry().getClosestPoint(ol.extent.getCenter(extent)));
-                        }
-                        return f.getGeometry();
-                    },
-                    text: new ol.style.Text({
-                        font: opts.textFont || '11pt sans-serif',
-                        text: feature.getProperties().label || "",
-                        overflow: true,
-                        fill: new ol.style.Fill({color: opts.textFill}),
-                        stroke: new ol.style.Stroke({color: opts.textStroke, width: 3}),
-                        textAlign: feature.getGeometry().getType() === "Point" ? 'left' : 'center',
-                        textBaseline: feature.getGeometry().getType() === "Point" ? 'bottom' : 'middle',
-                        offsetX: feature.getGeometry().getType() === "Point" ? (5 + opts.circleRadius) : 0
-                    })
-                })
-            );
-        }
-        if (feature.getProperties().segment_labels) {
-            const segmentLabels = feature.getProperties().segment_labels;
-            const coo = feature.getGeometry().getCoordinates();
-            for (let i = 0; i < coo.length - 1; ++i) {
-                const p1 = coo[i];
-                const p2 = coo[i + 1];
-                let angle = -Math.atan2(p2[1] - p1[1], p2[0] - p1[0]);
-                while (angle < -0.5 * Math.PI) {
-                    angle += Math.PI;
-                }
-                while (angle > 0.5 * Math.PI) {
-                    angle -= Math.PI;
-                }
-                styles.push(new ol.style.Style({
-                    geometry: new ol.geom.Point([0.5 * (p1[0] + p2[0]), 0.5 * (p1[1] + p2[1])]),
-                    text: new ol.style.Text({
-                        font: opts.textFont || '11pt sans-serif',
-                        text: segmentLabels[i],
-                        fill: new ol.style.Fill({color: opts.textFill}),
-                        stroke: new ol.style.Stroke({color: opts.textStroke, width: 3}),
-                        rotation: angle,
-                        offsetY: 10
-                    })
-                }));
+    }
+    if (feature.getProperties().segment_labels) {
+        const segmentLabels = feature.getProperties().segment_labels;
+        const coo = feature.getGeometry().getCoordinates();
+        for (let i = 0; i < coo.length - 1; ++i) {
+            const p1 = coo[i];
+            const p2 = coo[i + 1];
+            let angle = -Math.atan2(p2[1] - p1[1], p2[0] - p1[0]);
+            while (angle < -0.5 * Math.PI) {
+                angle += Math.PI;
             }
+            while (angle > 0.5 * Math.PI) {
+                angle -= Math.PI;
+            }
+            styles.push(new ol.style.Style({
+                geometry: new ol.geom.Point([0.5 * (p1[0] + p2[0]), 0.5 * (p1[1] + p2[1])]),
+                text: new ol.style.Text({
+                    font: opts.textFont || '11pt sans-serif',
+                    text: segmentLabels[i],
+                    fill: new ol.style.Fill({color: opts.textFill}),
+                    stroke: new ol.style.Stroke({color: opts.textStroke, width: 3}),
+                    rotation: angle,
+                    offsetY: 10
+                })
+            }));
         }
-        return styles;
-    },
+    }
+    return styles;
+};
+
+export default {
+    default: defaultStyle,
     marker: (feature, options) => {
         const opts = {...DEFAULT_MARKER_STYLE, ...ConfigUtils.getConfigProp("defaultMarkerStyle"), ...options};
         return [
@@ -128,6 +153,67 @@ export default {
                 })
             })
         ];
+    },
+    interaction: (options, isSnap) => {
+        const opts = {...DEFAULT_INTERACTION_STYLE, ...ConfigUtils.getConfigProp("defaultInteractionStyle"), ...options};
+        let fillColor = opts.fillColor;
+        let strokeColor = opts.strokeColor;
+        let strokeWidth = opts.strokeWidth;
+        let vertexFill = opts.vertexFillColor;
+        let vertexStroke = opts.vertexStrokeColor;
+        if (isSnap) {
+            fillColor = opts.snapFillColor;
+            strokeColor = opts.snapStrokeColor;
+            strokeWidth = opts.SnapStrokeWidth;
+            vertexFill = opts.snapVertexFillColor;
+            vertexStroke = opts.snapVertexStrokeColor;
+        }
+        return [
+            new ol.style.Style({
+                fill: new ol.style.Fill({ color: fillColor }),
+                stroke: new ol.style.Stroke({ color: strokeColor, width: strokeWidth})
+            }),
+            new ol.style.Style({
+                image: new ol.style.RegularShape({
+                    fill: new ol.style.Fill({ color: vertexFill }),
+                    stroke: new ol.style.Stroke({ color: vertexStroke, width: strokeWidth }),
+                    points: 4,
+                    radius: 5,
+                    angle: Math.PI / 4
+                }),
+            })
+        ]
+    },
+    measureInteraction: (feature, options) => {
+        const opts = {...DEFAULT_INTERACTION_STYLE, ...ConfigUtils.getConfigProp("defaultInteractionStyle"), ...options};
+        const styleOptions = {
+            strokeColor: opts.measureStrokeColor,
+            strokeWidth: opts.measureStrokeWidth,
+            fillColor: opts.measureFillColor,
+            strokeDash: []
+        };
+        return [
+            // Base geometry
+            ...defaultStyle(feature, styleOptions),
+            // Points
+            new ol.style.Style({
+                image: new ol.style.Circle({
+                    radius: opts.measurePointRadius,
+                    fill: new ol.style.Fill({color: opts.measurePointFillColor}),
+                    stroke: new ol.style.Stroke({ color: opts.measurePointStrokeColor, width: opts.measurePointStrokeWidth })
+                }),
+            })
+        ]
+    },
+    sketchInteraction: (options) => {
+        const opts = {...DEFAULT_INTERACTION_STYLE, ...ConfigUtils.getConfigProp("defaultInteractionStyle"), ...options};
+        return new ol.style.Style({
+            image: new ol.style.Circle({
+                fill: new ol.style.Fill({color: opts.sketchPointFillColor}),
+                stroke: new ol.style.Stroke({color: opts.sketchPointStrokeColor, width: opts.strokeWidth}),
+                radius: opts.sketchPointRadius
+            })
+        });
     },
     image: (feature, options) => {
         return new ol.style.Style({


### PR DESCRIPTION
For https://github.com/qgis/qwc2-demo-app/issues/462

Based on the utils/FeatureStyles and the config files mechanism:
 - Add Styling possibility for the marker via a new `defaultMarkerStyle` config key.
 - Moves Measure/snap/edit/redlining styling to FeatureStyle.
 - Add Styling possibility to Measure/snap/edit/redlining via a new `defaultInteractionStyle` config key.
 - Add missing modify style on redlining and edition and link it to the existing measurement modify style (now under the `DEFAULT_INTERACTION_STYLE.sketch...` keys).

I tried to keep every differences between edit/snap/measurement/redlining styles. Hope it's fine, let me know if I've to rework something.

Related PR:
 -  https://github.com/qwc-services/qwc-services.github.io/pull/10 (doc)
 - (no default config to add somewhere ?)