### PR TITLE
Searchbox Improvements

### DIFF
--- a/components/SearchBox.jsx
+++ b/components/SearchBox.jsx
@@ -445,7 +445,8 @@ class SearchBox extends React.Component {
         const searchParams = {
             mapcrs: this.props.map.projection,
             displaycrs: this.props.displaycrs,
-            lang: LocaleUtils.lang()
+            lang: LocaleUtils.lang(),
+            theme: this.props.theme
         };
         Object.entries(this.props.searchProviders).forEach(([key, entry]) => {
             pendingSearches.push(key);


### PR DESCRIPTION
If a search provider does not send _x_, _y_, and _bbox_ information, wait for the result of `getResultGeometry` and get the information for the resulting response.

We also added the active theme as a parameter to the search providers.