### PR TITLE
Fix wrong position on ResizableWindows when using docks

### DIFF
--- a/components/ResizeableWindow.jsx
+++ b/components/ResizeableWindow.jsx
@@ -298,6 +298,7 @@ class ResizeableWindow extends React.Component {
                 docked: !state.geometry.docked
             }
         }));
+        this.rnd.updatePosition(this.state.geometry);
     };
     toggleMinimize = () => {
         this.setState((state) => ({


### PR DESCRIPTION
This pull request aims to address a bug in the ResizableWindows with the Draggable component. Currently, when a ResizableWindow is initially docked to the right and then undocked, the component's default position, obtained from initialX and Y, appears to be correct. However, there is an issue with the Draggable component's state, which receives incorrect values. In our case, the Draggable component receives negative X values that don't seem to be related to other positions.

Another problem arises when a component is dragged to the middle of the screen, docked, closed, reopened, and then undocked again. The component fails to preserve its position from before it was docked. While the ResizableWindow shows the correct position, the DraggableComponent's values in the transform are doubled. Also, if the element is originally positioned in the opposite direction of the docked position and the same procedure is followed, the component disappears from the screen due to its position being doubled.

I tried applying users solutions but none of them worked for me [https://github.com/bokuweb/react-rnd/issues/846](url). I found that when adding the **updatePosition** function of the Rnd component inside the **toggleDock** function, it fixed the values of the draggable component, forcing draggable values to be corrected.

Any feedback or suggestions for improvements on this pull request are appreciated. If you need more information, please let me know.