### PR TITLE
bring window geometry configuration to all plugins with dockable window

### DIFF
--- a/components/LayerInfoWindow.jsx
+++ b/components/LayerInfoWindow.jsx
@@ -25,7 +25,7 @@ class LayerInfoWindow extends React.Component {
         scaleDependentLegend: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
         setActiveLayerInfo: PropTypes.func,
         sublayer: PropTypes.object,
-        windowSize: PropTypes.object
+        geometry: PropTypes.object,
     };
     renderLink(text, url) {
         if (url) {
@@ -64,7 +64,8 @@ class LayerInfoWindow extends React.Component {
             legend = (<span className="layer-info-window-coloricon" style={{backgroundColor: this.props.layer.color}} />);
         }
         return (
-            <ResizeableWindow icon="info-sign" initialHeight={this.props.windowSize.height} initialWidth={this.props.windowSize.width} onClose={this.onClose}
+            <ResizeableWindow icon="info-sign" initialHeight={this.props.layerInfoGeometry.initialHeight} initialWidth={this.props.layerInfoGeometry.initialWidth}
+                    initialX={this.props.layerInfoGeometry.initialX} initialY={this.props.layerInfoGeometry.initialY} initiallyDocked={this.props.layerInfoGeometry.initiallyDocked} onClose={this.onClose}
                 title={LocaleUtils.trmsg("layerinfo.title")}>
                 <div className="layer-info-window-body" role="body">
                     <h4 className="layer-info-window-title">{this.props.sublayer.title}</h4>

--- a/components/ServiceInfoWindow.jsx
+++ b/components/ServiceInfoWindow.jsx
@@ -19,7 +19,7 @@ class ServiceInfoWindow extends React.Component {
     static propTypes = {
         service: PropTypes.object,
         setActiveServiceInfo: PropTypes.func,
-        windowSize: PropTypes.object
+        layerInfoGeometry: PropTypes.object
     };
     renderLink(text, url) {
         if (url) {
@@ -47,7 +47,9 @@ class ServiceInfoWindow extends React.Component {
             return null;
         }
         return (
-            <ResizeableWindow icon="info-sign" initialHeight={this.props.windowSize.height} initialWidth={this.props.windowSize.width} onClose={this.onClose}
+            <ResizeableWindow icon="info-sign" initialHeight={this.props.layerInfoGeometry.initialHeight} initialWidth={this.props.layerInfoGeometry.initialWidth}
+                    initialX={this.props.layerInfoGeometry.initialX} initialY={this.props.layerInfoGeometry.initialY}
+                    initiallyDocked={this.props.layerInfoGeometry.initiallyDocked} onClose={this.onClose}
                 title={LocaleUtils.trmsg("serviceinfo.title")}>
                 <div className="service-info-window-body" role="body">
                     <h4 className="service-info-window-title">{this.props.service.title}</h4>

--- a/plugins/Cyclomedia.jsx
+++ b/plugins/Cyclomedia.jsx
@@ -39,7 +39,7 @@ class Cyclomedia extends React.Component {
         cyclomediaVersion: PropTypes.string,
         /** Whether to display Cyclomedia measurement geometries on the map. */
         displayMeasurements: PropTypes.bool,
-        /** Default window geometry. */
+        /** Default window geometry with size, position and docking status. */
         geometry: PropTypes.shape({
             initialWidth: PropTypes.number,
             initialHeight: PropTypes.number,
@@ -69,7 +69,7 @@ class Cyclomedia extends React.Component {
             initialHeight: 640,
             initialX: 0,
             initialY: 0,
-            initiallyDocked: true
+            initiallyDocked: false
         },
         maxMapScale: 10000,
         projection: 'EPSG:3857'
@@ -370,7 +370,7 @@ class Cyclomedia extends React.Component {
                         window.panoramaViewer.on(StreetSmartApi.Events.panoramaViewer.VIEW_CHANGE, changeView);
                         StreetSmartApi.on(StreetSmartApi.Events.measurement.MEASUREMENT_CHANGED, changeMeasurement);
                         StreetSmartApi.on(StreetSmartApi.Events.measurement.MEASUREMENT_STOPPED, stopMeasurement);
-                    }          
+                    }
                 }).catch((reason) => {
                     console.log('Failed to create component(s) through API: ' + reason);
                 });

--- a/plugins/FeatureForm.jsx
+++ b/plugins/FeatureForm.jsx
@@ -44,24 +44,27 @@ class FeatureForm extends React.Component {
         editContext: PropTypes.object,
         enabled: PropTypes.bool,
         iface: PropTypes.object,
-        /** Initial height of the form window. */
-        initialHeight: PropTypes.number,
-        /** Initial width of the form window. */
-        initialWidth: PropTypes.number,
-        /** Initial x position of the form window. */
-        initialX: PropTypes.number,
-        /** Initial y position of the form window. */
-        initialY: PropTypes.number,
+        /** Default window geometry with size, position and docking status. */
+        geometry: PropTypes.shape({
+            initialWidth: PropTypes.number,
+            initialHeight: PropTypes.number,
+            initialX: PropTypes.number,
+            initialY: PropTypes.number,
+            initiallyDocked: PropTypes.bool
+        }),
         layers: PropTypes.array,
         map: PropTypes.object,
         setEditContext: PropTypes.func,
         theme: PropTypes.object
     };
     static defaultProps = {
-        initialWidth: 320,
-        initialHeight: 480,
-        initialX: 0,
-        initialY: 0
+        geometry: {
+            initialWidth: 320,
+            initialHeight: 480,
+            initialX: 0,
+            initialY: 0,
+            initiallyDocked: false
+        }
     };
     static defaultState = {
         pendingRequests: 0,
@@ -192,9 +195,9 @@ class FeatureForm extends React.Component {
             }
             resultWindow = (
                 <ResizeableWindow icon="featureform"
-                    initialHeight={this.props.initialHeight} initialWidth={this.props.initialWidth}
-                    initialX={this.props.initialX} initialY={this.props.initialY}
-                    key="FeatureForm"
+                    initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
+                    initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
+                    initiallyDocked={this.props.geometry.initiallyDocked} key="FeatureForm"
                     onClose={this.clearResults} title={LocaleUtils.trmsg("featureform.title")}
                 >
                     {body}

--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -58,16 +58,14 @@ class Identify extends React.Component {
         /** Whether to assume that XML GetFeatureInfo responses specify the technical layer name in the `name` attribute, rather than the layer title. */
         featureInfoReturnsLayerName: PropTypes.bool,
         iframeDialogsInitiallyDocked: PropTypes.bool,
-        /** The initial height of the identify dialog. */
-        initialHeight: PropTypes.number,
-        /** The initial width of the identify dialog. */
-        initialWidth: PropTypes.number,
-        /** The initial x coordinate of the identify dialog. */
-        initialX: PropTypes.number,
-        /** The initial y coordinate of the identify dialog. */
-        initialY: PropTypes.number,
-        /** Whether the identify dialog should be initially docked. */
-        initiallyDocked: PropTypes.bool,
+        /** Default window geometry with size, position and docking status. */
+        geometry: PropTypes.shape({
+            initialWidth: PropTypes.number,
+            initialHeight: PropTypes.number,
+            initialX: PropTypes.number,
+            initialY: PropTypes.number,
+            initiallyDocked: PropTypes.bool
+        }),
         layers: PropTypes.array,
         longAttributesDisplay: PropTypes.string,
         map: PropTypes.object,
@@ -85,11 +83,14 @@ class Identify extends React.Component {
         longAttributesDisplay: 'ellipsis',
         displayResultTree: true,
         replaceImageUrls: true,
-        initialWidth: 240,
-        initialHeight: 320,
-        initialX: 0,
-        initialY: 0,
-        featureInfoReturnsLayerName: true
+        featureInfoReturnsLayerName: true,
+        geometry: {
+            initialWidth: 240,
+            initialHeight: 320,
+            initialX: 0,
+            initialY: 0,
+            initiallyDocked: false
+        }
     };
     state = {
         mode: 'Point',
@@ -375,8 +376,8 @@ class Identify extends React.Component {
             }
             resultWindow = (
                 <ResizeableWindow icon="info-sign"
-                    initialHeight={this.props.initialHeight} initialWidth={this.props.initialWidth}
-                    initialX={this.props.initialX} initialY={this.props.initialY} initiallyDocked={this.props.initiallyDocked}
+                    initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
+                    initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY} initiallyDocked={this.props.geometry.initiallyDocked}
                     key="IdentifyWindow"
                     onClose={this.clearResults} title={LocaleUtils.trmsg("identify.title")}
                 >

--- a/plugins/LayerCatalog.jsx
+++ b/plugins/LayerCatalog.jsx
@@ -57,14 +57,23 @@ class LayerCatalog extends React.Component {
         /** The URL to the catalog JSON file. */
         catalogUrl: PropTypes.string,
         setCurrentTask: PropTypes.func,
-        /** The default window size.  */
-        windowSize: PropTypes.shape({
-            width: PropTypes.number,
-            height: PropTypes.number
-        })
+        /** Default window geometry with size, position and docking status. */
+        geometry: PropTypes.shape({
+            initialWidth: PropTypes.number,
+            initialHeight: PropTypes.number,
+            initialX: PropTypes.number,
+            initialY: PropTypes.number,
+            initiallyDocked: PropTypes.bool
+        }),
     };
     static defaultProps = {
-        windowSize: {width: 320, height: 320}
+        geometry: {
+            initialWidth: 320,
+            initialHeight: 320,
+            initialX: 0,
+            initialY: 0,
+            initiallyDocked: false
+        }
     };
     state = {
         catalog: null
@@ -89,7 +98,8 @@ class LayerCatalog extends React.Component {
             return null;
         }
         return (
-            <ResizeableWindow icon="catalog" initialHeight={this.props.windowSize.height} initialWidth={this.props.windowSize.width}
+            <ResizeableWindow icon="catalog" initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
+                initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY} initiallyDocked={this.props.geometry.initiallyDocked}
                 onClose={this.onClose} title={LocaleUtils.trmsg("layercatalog.windowtitle")} >
                 <div className="layer-catalog" role="body">
                     <LayerCatalogWidget catalog={this.state.catalog} pendingRequests={0} />

--- a/plugins/LayerTree.jsx
+++ b/plugins/LayerTree.jsx
@@ -65,10 +65,13 @@ class LayerTree extends React.Component {
         groupTogglesSublayers: PropTypes.bool,
         /** Whether to display the layer info button inside the layer settings menu rather than next to the layer title. */
         infoInSettings: PropTypes.bool,
-        /** The initial size of the layer info window. */
-        layerInfoWindowSize: PropTypes.shape({
-            width: PropTypes.number,
-            height: PropTypes.number
+        /** Default layer info window geometry with size, position and docking status. */
+        layerInfoGeometry: PropTypes.shape({
+            initialWidth: PropTypes.number,
+            initialHeight: PropTypes.number,
+            initialX: PropTypes.number,
+            initialY: PropTypes.number,
+            initiallyDocked: PropTypes.bool
         }),
         layers: PropTypes.array,
         map: PropTypes.object,
@@ -111,7 +114,13 @@ class LayerTree extends React.Component {
         allowImport: true,
         groupTogglesSublayers: false,
         grayUnchecked: true,
-        layerInfoWindowSize: {width: 320, height: 480},
+        layerInfoGeometry: {
+            initialWidth: 480,
+            initialHeight: 480,
+            initialX: null,
+            initialY: null,
+            initiallyDocked: false
+        },
         bboxDependentLegend: false,
         flattenGroups: false,
         width: "25em",
@@ -508,8 +517,8 @@ class LayerTree extends React.Component {
                     })}
                 </SideBar>
                 {legendTooltip}
-                <LayerInfoWindow bboxDependentLegend={this.props.bboxDependentLegend} scaleDependentLegend={this.props.scaleDependentLegend} windowSize={this.props.layerInfoWindowSize} />
-                <ServiceInfoWindow windowSize={this.props.layerInfoWindowSize} />
+                <LayerInfoWindow bboxDependentLegend={this.props.bboxDependentLegend} scaleDependentLegend={this.props.scaleDependentLegend} layerInfoGeometry={this.props.layerInfoGeometry} />
+                <ServiceInfoWindow layerInfoGeometry={this.props.layerInfoGeometry} />
             </div>
         );
     }

--- a/plugins/MapLegend.jsx
+++ b/plugins/MapLegend.jsx
@@ -40,11 +40,14 @@ class MapLegend extends React.Component {
         /** Whether to display a scale-dependent legend by default. */
         scaleDependentLegend: PropTypes.bool,
         setCurrentTask: PropTypes.func,
-        /** The default window size. */
-        windowSize: PropTypes.shape({
-            width: PropTypes.number,
-            height: PropTypes.number
-        })
+        /** Default window geometry with size, position and docking status. */
+        geometry: PropTypes.shape({
+            initialWidth: PropTypes.number,
+            initialHeight: PropTypes.number,
+            initialX: PropTypes.number,
+            initialY: PropTypes.number,
+            initiallyDocked: PropTypes.bool
+        }),
     };
     static defaultProps = {
         addGroupTitles: false,
@@ -52,7 +55,13 @@ class MapLegend extends React.Component {
         bboxDependentLegend: false,
         onlyVisibleLegend: false,
         scaleDependentLegend: false,
-        windowSize: {width: 320, height: 320}
+        geometry: {
+            initialWidth: 320,
+            initialHeight: 320,
+            initialX: 0,
+            initialY: 0,
+            initiallyDocked: false
+        }
     };
     state = {
         onlyVisibleLegend: false,
@@ -85,8 +94,9 @@ class MapLegend extends React.Component {
         ];
 
         return (
-            <ResizeableWindow extraControls={extraControls} icon="list-alt" initialHeight={this.props.windowSize.height} initialWidth={this.props.windowSize.width}
-                onClose={this.onClose} title={LocaleUtils.trmsg("maplegend.windowtitle")} >
+            <ResizeableWindow extraControls={extraControls} icon="list-alt" initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
+                initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
+                initiallyDocked={this.props.geometry.initiallyDocked} onClose={this.onClose} title={LocaleUtils.trmsg("maplegend.windowtitle")} >
                 <div className="map-legend" role="body">
                     {this.props.layers.map(layer => {
                         if (this.state.onlyVisibleLegend && !layer.visibility) {

--- a/plugins/Routing.jsx
+++ b/plugins/Routing.jsx
@@ -48,7 +48,7 @@ class Routing extends React.Component {
         enabledModes: PropTypes.arrayOf(PropTypes.string),
         /** List of search providers to use for routing location search. */
         enabledProviders: PropTypes.arrayOf(PropTypes.string),
-        /** Default window geometry. */
+        /** Default window geometry with size, position and docking status. */
         geometry: PropTypes.shape({
             initialWidth: PropTypes.number,
             initialHeight: PropTypes.number,

--- a/plugins/TimeManager.jsx
+++ b/plugins/TimeManager.jsx
@@ -144,7 +144,15 @@ class TimeManager extends React.Component {
             markerPins: true
         },
         featureTimelineAvailable: true,
-        stepUnits: ["s", "m", "h", "d", "M", "y"]
+        stepUnits: ["s", "m", "h", "d", "M", "y"],
+        /** Default window geometry with size, position and docking status. */
+        geometry: PropTypes.shape({
+            initialWidth: PropTypes.number,
+            initialHeight: PropTypes.number,
+            initialX: PropTypes.number,
+            initialY: PropTypes.number,
+            initiallyDocked: PropTypes.bool
+        }),
     };
     static defaultState = {
         timeEnabled: false,
@@ -170,7 +178,14 @@ class TimeManager extends React.Component {
         },
         timeFeatures: null,
         settingsPopup: false,
-        visible: false
+        visible: false,
+        geometry: {
+            initialWidth: 900,
+            initialHeight: 320,
+            initialX: null,
+            initialY: null,
+            initiallyDocked: false
+        }
     };
     constructor(props) {
         super(props);
@@ -297,8 +312,9 @@ class TimeManager extends React.Component {
             body = this.renderBody(timeValues);
         }
         return (
-            <ResizeableWindow dockable="bottom"  icon="time" initialHeight={320}
-                initialWidth={900} onClose={this.onClose} onGeometryChanged={this.dialogGeomChanged}
+            <ResizeableWindow dockable="bottom"  icon="clock" initialHeight={this.props.geometry.initialHeight}
+                initialWidth={this.props.geometry.initialWidth} initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
+                initiallyDocked={this.props.geometry.initiallyDocked} onClose={this.onClose} onGeometryChanged={this.dialogGeomChanged}
                 scrollable splitScreenWhenDocked title={LocaleUtils.tr("timemanager.title")}>
                 {body}
             </ResizeableWindow>


### PR DESCRIPTION
In some plugings it was already possible to specify the geoemtry of the dockable window with `initialWidth`, `initialHeight`, `initialX`, `initialY` and `initiallyDocked`.
This pull request brings this configuration possibility to all the other plugins with dockable windows and match the parameter names.