### PR TITLE
Dynamic plugins for mapinfotooltip

### DIFF
--- a/plugins/MapInfoTooltip.jsx
+++ b/plugins/MapInfoTooltip.jsx
@@ -56,16 +56,16 @@ class MapInfoTooltip extends React.Component {
         plugins: {}
     };
     state = {
-        coordinate: null, elevation: null, extraInfo: null, newPoint: null
+        point: null, elevation: null, extraInfo: null
     };
     componentDidUpdate(prevProps) {
-        if (!this.props.enabled && this.state.coordinate) {
+        if (!this.props.enabled && this.state.point) {
             this.clear();
             return;
         }
         const newPoint = this.props.map.click;
         if (!newPoint || newPoint.button !== 2) {
-            if (this.state.coordinate) {
+            if (this.state.point) {
                 this.clear();
             }
         } else {

--- a/plugins/MapInfoTooltip.jsx
+++ b/plugins/MapInfoTooltip.jsx
@@ -32,6 +32,16 @@ import './style/MapInfoTooltip.css';
  * 
  * If `mapInfoService` in `config.json` points to a `qwc-mapinfo-service`, additional
  * custom information according to the `qwc-mapinfo-service` configuration is returned.
+ * 
+ * To add external plugins to the tooltip, include your plugin in the `plugins` array
+ * inside the `MapInfoTooltip` section of the `AppConfig` file.
+ * 
+ * Example:
+ * ```json
+ * {
+ *  MapInfoTooltipPlugin: MapInfoTooltipPlugin([FirstPlugin, SecondPlugin])
+ * }
+ * ```
  */
 class MapInfoTooltip extends React.Component {
     static propTypes = {
@@ -46,7 +56,7 @@ class MapInfoTooltip extends React.Component {
         includeWGS84: PropTypes.bool,
         map: PropTypes.object,
         setCurrentTask: PropTypes.func,
-        plugins: PropTypes.object
+        plugins: PropTypes.array
     };
     static defaultProps = {
         cooPrecision: 0,
@@ -96,7 +106,7 @@ class MapInfoTooltip extends React.Component {
         if (!this.state.point) {
             return null;
         }
-        
+
         const info = [];
 
         const projections = [this.props.displaycrs];
@@ -183,7 +193,7 @@ class MapInfoTooltip extends React.Component {
                             </tbody>
                         </table>
                         {routingButtons}
-                        {Object.values(this.props.plugins).map((Plugin, idx) => (<Plugin key={idx} point={this.state.point} closePopup={this.clear} />))}
+                        {this.props.plugins.map((Plugin, idx) => (<Plugin key={idx} point={this.state.point} closePopup={this.clear} />))}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Be able to add plugins to the tooltip and there is no need to change this file, in the appConfig file the user must add his plugin to the list of plugins and it will be automatically added.
At the moment, I have only made a list of 3 props that can be sent that are configured in the plugin's cfg export. This list can be expanded.
