### PR TITLE
Do not prepend img/mapthumbs/ to generated path to WMTS thumbnail

### DIFF
--- a/scripts/wmts_config_generator.py
+++ b/scripts/wmts_config_generator.py
@@ -154,7 +154,7 @@ result = {
         "bounds": bounds
     },
     "resolutions": resolutions,
-    "thumbnail": "img/mapthumbs/" + layerName + ".jpg",
+    "thumbnail": layerName + ".jpg",
 }
 
 print(json.dumps(result, indent=2))


### PR DESCRIPTION
`wmts_config_generator.py` script prepends `img/mapthumbs/` to path to thumbnail image.

However, this will not work, as `themesConfig.js` is itself always adding `img/mapthumbs/` when checking whether the thumbnail exists or not, meaning the output path will not exists. Also [the docs said](https://qwc-services.github.io/configuration/ThemesConfiguration/#background-layers):

> Optional, image file in assets/img/mapthumbs (see [Viewer assets](https://qwc-services.github.io/configuration/ViewerConfiguration/#viewer-asset)). Defaults to default.jpg.

... which properly corresponds to the actual behavior, but not with `wmts_config_generator.py` output.