### PR TITLE
Icons of inline window opened from TopBar and BottomBar

### DIFF
--- a/components/AppMenu.jsx
+++ b/components/AppMenu.jsx
@@ -191,7 +191,7 @@ class AppMenu extends React.Component {
             this.toggleMenu();
         }
         if (item.url) {
-            this.props.openExternalUrl(item.url, item.target, LocaleUtils.tr("appmenu.items." + item.key));
+            this.props.openExternalUrl(item.url, item.target, LocaleUtils.tr("appmenu.items." + item.key), item.icon);
         } else {
             this.props.setCurrentTask(item.task || item.key, item.mode, item.mapClickAction || (item.identifyEnabled ? "identify" : null));
         }

--- a/components/WindowManager.jsx
+++ b/components/WindowManager.jsx
@@ -46,7 +46,7 @@ class WindowManager extends React.Component {
         const dockable = this.boolVal(data.options.dockable) !== false;
         const docked = this.boolVal(data.options.docked) !== false;
         return (
-            <ResizeableWindow dockable={dockable || docked} extraControls={extraControls} icon={data.icon || ""}
+            <ResizeableWindow dockable={dockable || docked} extraControls={extraControls} icon={data.options.icon || ""}
                 initialHeight={data.options.h || 480}
                 initialWidth={data.options.w || 640}
                 initiallyDocked={docked} key={key}

--- a/plugins/BottomBar.jsx
+++ b/plugins/BottomBar.jsx
@@ -43,10 +43,14 @@ class BottomBar extends React.Component {
         showIframeDialog: PropTypes.func,
         /** The URL of the terms label anchor. */
         termsUrl: PropTypes.string,
+        /** Icon of the terms inline window. Relevant only when `termsUrlTarget` is `iframe`. */
+        termsUrlIcon: PropTypes.string,
         /** The target where to open the terms URL. If `iframe`, it will be displayed in an inline window, otherwise in a new tab. */
         termsUrlTarget: PropTypes.string,
         /** The URL of the viewer title label anchor. */
         viewertitleUrl: PropTypes.string,
+        /** Icon of the viewer title inline window. Relevant only when `viewertitleUrl` is `iframe`. */
+        viewertitleUrlIcon: PropTypes.string,
         /** The target where to open the viewer title URL. If `iframe`, it will be displayed in an inline window, otherwise in a new tab. */
         viewertitleUrlTarget: PropTypes.string
     };
@@ -76,7 +80,7 @@ class BottomBar extends React.Component {
         let viewertitleLink;
         if (this.props.viewertitleUrl) {
             viewertitleLink = (
-                <a href={this.props.viewertitleUrl} onClick={(ev) => this.openUrl(ev, this.props.viewertitleUrl, this.props.viewertitleUrlTarget, LocaleUtils.tr("bottombar.viewertitle_label"))}>
+                <a href={this.props.viewertitleUrl} onClick={(ev) => this.openUrl(ev, this.props.viewertitleUrl, this.props.viewertitleUrlTarget, LocaleUtils.tr("bottombar.viewertitle_label"), this.props.viewertitleUrlIcon)}>
                     <span className="viewertitle_label">{LocaleUtils.tr("bottombar.viewertitle_label")}</span>
                 </a>
             );
@@ -84,7 +88,7 @@ class BottomBar extends React.Component {
         let termsLink;
         if (this.props.termsUrl) {
             termsLink = (
-                <a href={this.props.termsUrl} onClick={(ev) => this.openUrl(ev, this.props.termsUrl, this.props.termsUrlTarget, LocaleUtils.tr("bottombar.terms_label"))}>
+                <a href={this.props.termsUrl} onClick={(ev) => this.openUrl(ev, this.props.termsUrl, this.props.termsUrlTarget, LocaleUtils.tr("bottombar.terms_label"), this.props.termsUrlIcon)}>
                     <span className="terms_label">{LocaleUtils.tr("bottombar.terms_label")}</span>
                 </a>
             );
@@ -151,10 +155,10 @@ class BottomBar extends React.Component {
             </div>
         );
     }
-    openUrl = (ev, url, target, title) => {
+    openUrl = (ev, url, target, title, icon) => {
         ev.preventDefault();
         if (target === "iframe") {
-            this.props.showIframeDialog("externallinkiframe", url, {title: title});
+            this.props.showIframeDialog("externallinkiframe", url, {title: title, icon: icon});
         } else {
             this.props.openExternalUrl(url);
         }

--- a/plugins/TopBar.jsx
+++ b/plugins/TopBar.jsx
@@ -132,9 +132,9 @@ class TopBar extends React.Component {
             </Swipeable>
         );
     }
-    openUrl = (url, target, title) => {
+    openUrl = (url, target, title, icon) => {
         if (target === "iframe") {
-            this.props.showIframeDialog("externallinkiframe", url, {title: title});
+            this.props.showIframeDialog("externallinkiframe", url, {title: title, icon: icon});
         } else {
             this.props.openExternalUrl(url);
         }


### PR DESCRIPTION
Currently, when iframe inline window is opened from either TopBar or BottomBar, they won't get any icon as other windows do. 

For example layers catalog window does have icon:
![obrazek](https://github.com/qgis/qwc2/assets/793041/063d3a68-a232-4272-a201-1114c810231d)

However custom iframe windows won't get any icon:
![obrazek](https://github.com/qgis/qwc2/assets/793041/fa683e57-e41e-4c0f-8baf-7a7c70b7619c)

This PR reuses the (already required) `icon` of `menuItems` in TopBar as icon of the window.

```js
"menuItems": [
    {
        "key": "ExternalLink",
        "icon": "link", // this icon was already required, but was only used in the menu, now it is also passed to the window
        "url": "http://example.com",
        "target": "iframe"
    }
]
```

![obrazek](https://github.com/qgis/qwc2/assets/793041/7ce9104a-6628-4305-b7cd-efe73e3431eb)

It also adds special keys (`termsUrlIcon` and `viewertitleUrlIcon`) to define icons of links also in BottomBar configuration.

What do you think?