### PR TITLE
Make icon of resizable window large, so it is the same size as sidebar window icon

### DIFF
--- a/components/ResizeableWindow.jsx
+++ b/components/ResizeableWindow.jsx
@@ -165,7 +165,7 @@ class ResizeableWindow extends React.Component {
         }
         let icon = null;
         if (this.props.icon) {
-            icon = (<Icon className="resizeable-window-titlebar-icon" icon={this.props.icon} />);
+            icon = (<Icon className="resizeable-window-titlebar-icon" icon={this.props.icon} size="large" />);
         }
         const bodyclasses = classnames({
             "resizeable-window-body": true,


### PR DESCRIPTION
Currently, icons of resizable windows are smaller (14px) than icons of sidebar windows (21px), which look optically uneven:

![obrazek](https://github.com/qgis/qwc2/assets/793041/5e6687a1-7d29-48bb-8817-2e12c62edb0b)

This PR changes icon size of resizable windows to large, the same size as is icon in sidebar window:

![obrazek](https://github.com/qgis/qwc2/assets/793041/5689c072-57f1-4d7c-a5cb-fdd89ae9cea9)

