### PR TITLE
Account for file created by yarn install in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 node_modules/
 npm-debug.log
+
+# On a fresh install with yarn 3.3.0 these extra files were generated.
+.yarn
+.pnp.cjs
+.pnp.loader.mjs
+yarn.lock


### PR DESCRIPTION
On a fresh `git clone` followed by `yarn install` there are some files that are not excluded by `.gitignore`.