### PR TITLE
Insert when a layer attribute is not found is being silently ignored.

### DIFF
--- a/utils/LayerUtils.js
+++ b/utils/LayerUtils.js
@@ -469,7 +469,10 @@ const LayerUtils = {
         if (index !== -1) {
             exploded.splice(index, 0, ...explodedAdd);
         } else {
-            exploded.splice(exploded.length, 0, ...explodedAdd);
+            throw new Error(
+                "Failed to find 'before' layer item with " + 
+                `'${beforeAttr}'=${beforeVal}`
+            );
         }
         return LayerUtils.implodeLayers(exploded);
     },

--- a/utils/LayerUtils.js
+++ b/utils/LayerUtils.js
@@ -468,6 +468,8 @@ const LayerUtils = {
         const index = exploded.findIndex(entry => entry.sublayer[beforeattr] === beforeval);
         if (index !== -1) {
             exploded.splice(index, 0, ...explodedAdd);
+        } else {
+            exploded.splice(exploded.length, 0, ...explodedAdd);
         }
         return LayerUtils.implodeLayers(exploded);
     },


### PR DESCRIPTION
Either this or a console warning / assertion. It is used by the `addLayer` action, so maybe throwing an error is better?