### PR TITLE
replace int id with uuid for kml import

### DIFF
--- a/utils/VectorLayerUtils.js
+++ b/utils/VectorLayerUtils.js
@@ -283,7 +283,6 @@ const VectorLayerUtils = {
         const kmlFormat = new ol.format.KML({defaultStyle: [new ol.style.Style()]});
         const geojsonFormat = new ol.format.GeoJSON();
         const features = [];
-        let fid = 0;
         for (const olFeature of kmlFormat.readFeatures(kml)) {
             let style = olFeature.getStyleFunction()(olFeature);
             style = style[0] || style;
@@ -317,7 +316,6 @@ const VectorLayerUtils = {
                 crs: "EPSG:4326",
                 properties: {}
             });
-            fid++
             const properties = olFeature.getProperties();
             const excludedProperties = ['visibility', olFeature.getGeometryName()];
             for (const key of Object.keys(properties)) {

--- a/utils/VectorLayerUtils.js
+++ b/utils/VectorLayerUtils.js
@@ -313,10 +313,11 @@ const VectorLayerUtils = {
             Object.assign(feature, {
                 styleName: styleOptions.iconSrc ? 'marker' : 'default',
                 styleOptions: styleOptions,
-                id: fid++,
+                id: uuidv1(),
                 crs: "EPSG:4326",
                 properties: {}
             });
+            fid++
             const properties = olFeature.getProperties();
             const excludedProperties = ['visibility', olFeature.getGeometryName()];
             for (const key of Object.keys(properties)) {


### PR DESCRIPTION
Right now, KML import uses integer types for IDs, which works but creates an error when you try to edit the layer with redlining. All elements disappear. Using a UUID, like the GeoJSON imports, seems to work better.