### PR TITLE
Add projection to MapInfoToolTip

### DIFF
--- a/plugins/MapInfoTooltip.jsx
+++ b/plugins/MapInfoTooltip.jsx
@@ -199,7 +199,7 @@ class MapInfoTooltip extends React.Component {
                             </tbody>
                         </table>
                         {routingButtons}
-                        {this.props.plugins.map((Plugin, idx) => (<Plugin key={idx} point={this.state.point} closePopup={this.clear} />))}
+                        {this.props.plugins.map((Plugin, idx) => (<Plugin key={idx} point={this.state.point} closePopup={this.clear} projection={this.props.map.projection} />))}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
It could be interesting to pass the projection along with the point to the Tooltip plugin. This way, it's possible to perform transformations into different EPSG using CoordinatesUtils.reproject.

Doing this could allow for  interfaces between the tooltip and external applications that may expect a different projection than the one used in the map.

What do you think about this idea?

Thanks and kind regards,
Clément.