### PR TITLE
Also close 'failure' process notification

### DIFF
--- a/plugins/ProcessNotifications.jsx
+++ b/plugins/ProcessNotifications.jsx
@@ -50,6 +50,9 @@ class ProcessNotifications extends React.Component {
             icon = (<Icon icon="ok" />);
             close = true;
         } else if (process.status === ProcessStatus.FAILURE) {
+            setTimeout(() => {
+                this.props.clearProcess(process.id);
+            }, 12000);
             icon = (<Icon icon="warning" />);
             close = true;
         }


### PR DESCRIPTION
I think it's a good idea to also close the process notification when the status is 'failure'. This way we avoid having a stack of multiple "failure" notifications on screen if, for some reason, there is multiple of them in a short period of time.