### PR TITLE
Fix print download on chrome when using inlinePrintOutput

### DIFF
--- a/plugins/Print.jsx
+++ b/plugins/Print.jsx
@@ -542,9 +542,9 @@ class Print extends React.Component {
         return [x1, y1, x2, y2];
     };
     print = (ev) => {
-        if (this.props.inlinePrintOutput) {
-            this.setState({printOutputVisible: true, outputLoaded: false});
-        }
+            if (this.props.inlinePrintOutput) {
+                this.setState({printOutputVisible: true, outputLoaded: false});
+            }
             ev.preventDefault();
             this.setState({printing: true});
             const formData = formDataEntries(new FormData(this.printForm));


### PR DESCRIPTION
Should fix https://github.com/qgis/qwc2-demo-app/issues/504.
Didn't find solution for the filename but, since you get the correct .pdf and you save it you can change the name anyway so maybe it's not that bad.

Let me know if it works for you.
I've tested to some extent with the demo project on firefox and chrome but not with atlas.

Kind regards,
Clement.