### PR TITLE
Do not reproject geometry for GeoJson format from GetFeatureInfo resp…

### DIFF
--- a/utils/IdentifyUtils.js
+++ b/utils/IdentifyUtils.js
@@ -314,14 +314,10 @@ const IdentifyUtils = {
             if (result[layer.name] === undefined) {
                 result[layer.name] = [];
             }
-            let geometry = feature.geometry;
-            if (geometry) {
-                geometry = VectorLayerUtils.reprojectGeometry(geometry, "EPSG:4326", geometrycrs); // GeoJSON always wgs84
-            }
             result[layer.name].push({
                 ...feature,
                 id: id,
-                geometry: geometry,
+                geometry: feature.geometry,
                 layername: layer.name,
                 layertitle: layer.title
             });

--- a/utils/IdentifyUtils.js
+++ b/utils/IdentifyUtils.js
@@ -314,10 +314,15 @@ const IdentifyUtils = {
             if (result[layer.name] === undefined) {
                 result[layer.name] = [];
             }
+            let geometry = feature.geometry;
+            if (geometry && response.crs) {
+                // Reproject geometry only if there is crs information in GetFeatureInfo response
+                geometry = VectorLayerUtils.reprojectGeometry(geometry, response.crs.properties?.name ?? "EPSG:4326", geometrycrs);
+            }
             result[layer.name].push({
                 ...feature,
                 id: id,
-                geometry: feature.geometry,
+                geometry: geometry,
                 layername: layer.name,
                 layertitle: layer.title
             });


### PR DESCRIPTION
…onse as it is not necessary EPSG:4326 anymore

Hi @manisandro 

I'm not sure about this one... Maybe it breaks something elsewhere...

The problem is when we identify objects from external WMS added to the map, the geometry is not highlighted because there is a reprojection for GeoJSON format from EPSG:4326 to the map projection.

GetFeatureInfo from theme. Geometry is highlighted:

![image](https://github.com/qgis/qwc2/assets/8960009/2095869f-1a7e-4731-acba-ba2367157727)

Import layer as WMS, and identify object. Geometry is not highlighted:

![image](https://github.com/qgis/qwc2/assets/8960009/10f57194-786f-47fe-b38f-bf2c3543e0a4)

Without reprojection from 4326 to the map projection, geometry is highlighted because response is well parsed (it has already the right projection from request parameter):

![image](https://github.com/qgis/qwc2/assets/8960009/91dd94b6-1e21-45e6-83f6-509c4363b732)

GetFeatureInfo geometry response for geojson format is not necessary EPSG:4326 anymore. It can be other CRS, see this PR: https://github.com/qgis/QGIS/pull/32386

Thanks