### PR TITLE
Select format when printing layout

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -429,7 +429,7 @@ Allows exporting a selected portion of the map to a variety of formats.
 | defaultScaleFactor | `number` | The factor to apply to the map scale to determine the initial export map scale (if `allowedScales` is not `false`). | `0.5` |
 | dpis | `[number]` | List of dpis at which to export the map. If empty, the default server dpi is used. | `undefined` |
 | exportExternalLayers | `bool` | Whether to include external layers in the image. Requires QGIS Server 3.x! | `true` |
-| formatConfiguration | `{`<br />`  format: [{`<br />`  name: string,`<br />`  extraQuery: string,`<br />`  formatOptions: string,`<br />`  baseLayer: string,`<br />`}],`<br />`}` | Custom export configuration per format.<br /> If more than one configuration per format is provided, a selection combo will be displayed.<br /> `query` will be appended to the query string (replacing any existing parameters).<br /> `formatOptions` will be passed as FORMAT_OPTIONS.<br /> `baseLayer` will be appended to the LAYERS instead of the background layer. | `undefined` |
+| formatConfiguration | `{`<br />`  format: [{`<br />`  name: string,`<br />`  extraQuery: string,`<br />`  formatOptions: string,`<br />`  baseLayer: string,`<br />`}],`<br />`}` | Custom export configuration per format.<br /> If more than one configuration per format is provided, a selection combo will be displayed.<br /> `extraQuery` will be appended to the query string (replacing any existing parameters).<br /> `formatOptions` will be passed as FORMAT_OPTIONS.<br /> `baseLayer` will be appended to the LAYERS instead of the background layer. | `undefined` |
 | pageSizes | `[{`<br />`  name: string,`<br />`  width: number,`<br />`  height: number,`<br />`}]` | List of image sizes to offer, in addition to the free-hand selection. The width and height are in millimeters. | `[`<br />`    {name: '15 x 15 cm', width: 150, height: 150},`<br />`    {name: '30 x 30 cm', width: 300, height: 300}`<br />`]` |
 | side | `string` | The side of the application on which to display the sidebar. | `'right'` |
 
@@ -479,9 +479,9 @@ The user can toggle whether to display only layers which are enabled, visible in
 | addLayerTitles | `bool` | Whether to add layer titles to the legend. Note that often the legend image itself already contains the layer title. | `false` |
 | bboxDependentLegend | `bool` | Whether to display a BBOX-dependent legend by default. | `false` |
 | extraLegendParameters | `string` | Extra parameters to add to the GetLegendGraphics request. | `undefined` |
+| geometry | `{`<br />`  initialWidth: number,`<br />`  initialHeight: number,`<br />`  initialX: number,`<br />`  initialY: number,`<br />`  initiallyDocked: bool,`<br />`}` | Default window geometry with size, position and docking status. | `{`<br />`    initialWidth: 320,`<br />`    initialHeight: 320,`<br />`    initialX: 0,`<br />`    initialY: 0,`<br />`    initiallyDocked: false`<br />`}` |
 | onlyVisibleLegend | `bool` | Whether to only include enabled layers in the legend by default. | `false` |
 | scaleDependentLegend | `bool` | Whether to display a scale-dependent legend by default. | `false` |
-| geometry | `{`<br />`  initialWidth: number,`<br />`  initialHeight: number,`<br />`  initialX: number,`<br />`  initialY: number,`<br />`  initiallyDocked: bool,`<br />`}` | Default window geometry with size, position and docking status. | `{`<br />`    initialWidth: 320,`<br />`    initialHeight: 320,`<br />`    initialX: 0,`<br />`    initialY: 0,`<br />`    initiallyDocked: false`<br />`}` |
 
 MapTip<a name="maptip"></a>
 ----------------------------------------------------------------
@@ -529,6 +529,7 @@ Uses the print layouts defined in the QGIS project.
 | defaultDpi | `number` | The default print dpi. | `300` |
 | defaultScaleFactor | `number` | The factor to apply to the map scale to determine the initial print map scale. | `0.5` |
 | displayRotation | `bool` | Whether to display the map rotation control. | `true` |
+| formats | `[string]` | Export layout format mimetypes. If empty, supported formats are listed. If format is not supported by QGIS Server, print will fail | `undefined` |
 | gridInitiallyEnabled | `bool` | Whether the grid is enabled by default. | `false` |
 | hideAutopopulatedFields | `bool` | Whether to hide form fields which contain autopopulated values (i.e. search result label). | `undefined` |
 | inlinePrintOutput | `bool` | Whether to display the print output in an inline dialog instead triggering a download. | `false` |

--- a/plugins/Print.jsx
+++ b/plugins/Print.jsx
@@ -51,6 +51,8 @@ class Print extends React.Component {
         defaultScaleFactor: PropTypes.number,
         /** Whether to display the map rotation control. */
         displayRotation: PropTypes.bool,
+        /** Export layout format mimetypes. If empty, supported formats are listed. If format is not supported by QGIS Server, print will fail */
+        formats: PropTypes.arrayOf(PropTypes.string),
         /** Whether the grid is enabled by default. */
         gridInitiallyEnabled: PropTypes.bool,
         /** Whether to hide form fields which contain autopopulated values (i.e. search result label). */
@@ -92,7 +94,7 @@ class Print extends React.Component {
         printing: false,
         atlasFeatures: [],
         geoPdf: false,
-        availableFormats: ['application/pdf', 'image/jpeg', 'image/png', 'image/svg'],
+        availableFormats: [],
         selectedFormat: null
     };
     constructor(props) {
@@ -100,7 +102,6 @@ class Print extends React.Component {
         this.printForm = null;
         this.state.grid = props.gridInitiallyEnabled;
         this.fixedMapCenter = null;
-        this.state.selectedFormat = 'application/pdf';
     }
     componentDidUpdate(prevProps, prevState) {
         if (prevProps.theme !== this.props.theme) {
@@ -129,6 +130,9 @@ class Print extends React.Component {
         }
     }
     onShow = () => {
+        const defaultFormats = ['application/pdf', 'image/jpeg', 'image/png', 'image/svg'];
+        const availableFormats = !isEmpty(this.props.formats) ? this.props.formats : defaultFormats;
+        const selectedFormat = availableFormats[0];
         let scale = Math.round(MapUtils.computeForZoom(this.props.map.scales, this.props.map.zoom) * this.props.defaultScaleFactor);
         if (this.props.theme.printScales && this.props.theme.printScales.length > 0) {
             let closestVal = Math.abs(scale - this.props.theme.printScales[0]);
@@ -142,7 +146,13 @@ class Print extends React.Component {
             }
             scale = this.props.theme.printScales[closestIdx];
         }
-        this.setState({scale: scale, initialRotation: this.props.map.bbox.rotation, dpi: this.props.defaultDpi});
+        this.setState({
+            scale: scale,
+            initialRotation: this.props.map.bbox.rotation,
+            dpi: this.props.defaultDpi,
+            availableFormats: availableFormats,
+            selectedFormat: selectedFormat
+        });
     };
     onHide = () => {
         this.props.changeRotation(this.state.initialRotation);

--- a/plugins/Print.jsx
+++ b/plugins/Print.jsx
@@ -447,7 +447,7 @@ class Print extends React.Component {
                             <Spinner /> {LocaleUtils.tr("print.wait")}
                         </span>
                     ) : null}
-                    <iframe src={this.state.pdfData} name="print-output-window" onLoad={() => this.setState({outputLoaded: true})}/>
+                    <iframe name="print-output-window" onLoad={() => this.setState({outputLoaded: true})} src={this.state.pdfData}/>
                 </div>
             </ResizeableWindow>
         );
@@ -560,10 +560,9 @@ class Print extends React.Component {
             const contentType = response.headers["content-type"];
             const file = new Blob([response.data], { type: contentType });
             if (this.props.inlinePrintOutput) {
-                const fileURL = URL.createObjectURL(file); 
+                const fileURL = URL.createObjectURL(file);
                 this.setState({ pdfData: fileURL, outputLoaded: true });
-            }
-            else {
+            } else {
                 FileSaver.saveAs(file, this.props.theme.name + '.pdf');
             }
         }).catch(e => {

--- a/translations/ca-ES.json
+++ b/translations/ca-ES.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "",
+      "format": "Format",
       "grid": "Graella",
       "layout": "Diseny",
       "legend": "Llegenda",

--- a/translations/cs-CZ.json
+++ b/translations/cs-CZ.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "",
+      "format": "Formát",
       "grid": "Mřížka:",
       "layout": "Rovržení:",
       "legend": "Legenda",

--- a/translations/de-CH.json
+++ b/translations/de-CH.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "Atlasobjekt",
+      "format": "Format",
       "grid": "Gitter",
       "layout": "Format",
       "legend": "Legende",
@@ -299,7 +300,7 @@
       "resolution": "Auflösung",
       "rotation": "Rotation",
       "scale": "Massstab",
-      "submit": "PDF erzeugen",
+      "submit": "Erzeugen",
       "wait": "Bitte warten..."
     },
     "qtdesignerform": {

--- a/translations/de-DE.json
+++ b/translations/de-DE.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "Atlasobjekt",
+      "format": "Format",
       "grid": "Gitter",
       "layout": "Format",
       "legend": "Legende",
@@ -299,7 +300,7 @@
       "resolution": "Auflösung",
       "rotation": "Rotation",
       "scale": "Maßstab",
-      "submit": "PDF erzeugen",
+      "submit": "Erzeugen",
       "wait": "Bitte warten..."
     },
     "qtdesignerform": {

--- a/translations/en-US.json
+++ b/translations/en-US.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "Atlas feature",
+      "format": "Format",
       "grid": "Grid",
       "layout": "Layout",
       "legend": "Legend",

--- a/translations/es-ES.json
+++ b/translations/es-ES.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "",
+      "format": "Formato:",
       "grid": "Grilla:",
       "layout": "Diseño:",
       "legend": "Leyenda",

--- a/translations/fi-FI.json
+++ b/translations/fi-FI.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "",
+      "format": "Formaatti",
       "grid": "Ristikko",
       "layout": "Layout",
       "legend": "Selite",

--- a/translations/fr-FR.json
+++ b/translations/fr-FR.json
@@ -287,8 +287,9 @@
     },
     "print": {
       "atlasfeature": "Objet atlas",
+      "format": "Format",
       "grid": "Grille",
-      "layout": "Format",
+      "layout": "Mise en page",
       "legend": "Légende",
       "maximize": "Maximiser",
       "minimize": "Minimiser",
@@ -299,7 +300,7 @@
       "resolution": "Résolution",
       "rotation": "Rotation",
       "scale": "Echelle",
-      "submit": "Créer le PDF",
+      "submit": "Imprimer",
       "wait": "Veuillez patienter..."
     },
     "qtdesignerform": {

--- a/translations/hu-HU.json
+++ b/translations/hu-HU.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "",
+      "format": "Formátum",
       "grid": "Rács",
       "layout": "Elrendezés",
       "legend": "",

--- a/translations/it-IT.json
+++ b/translations/it-IT.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "Oggetto atlante",
+      "format": "Formato",
       "grid": "Griglia",
       "layout": "Layout",
       "legend": "Legenda",

--- a/translations/no-NO.json
+++ b/translations/no-NO.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "",
+      "format": "Format",
       "grid": "Rutenett",
       "layout": "Layout",
       "legend": "",

--- a/translations/pl-PL.json
+++ b/translations/pl-PL.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "",
+      "format": "Format",
       "grid": "Siatka",
       "layout": "Layout",
       "legend": "",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "Feições do atlas",
+      "format": "Formato",
       "grid": "Grade",
       "layout": "Layout",
       "legend": "Legenda",

--- a/translations/pt-PT.json
+++ b/translations/pt-PT.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "",
+      "format": "Formato",
       "grid": "Rede",
       "layout": "Desenho",
       "legend": "",

--- a/translations/ro-RO.json
+++ b/translations/ro-RO.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "Obiect în atlas",
+      "format": "",
       "grid": "Grid",
       "layout": "Șablon",
       "legend": "Legendă",

--- a/translations/ru-RU.json
+++ b/translations/ru-RU.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "",
+      "format": "Формат бумаги",
       "grid": "Сетка",
       "layout": "Формат бумаги",
       "legend": "",

--- a/translations/sv-SE.json
+++ b/translations/sv-SE.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "",
+      "format": "Format",
       "grid": "Rutnät",
       "layout": "Layout:",
       "legend": "",

--- a/translations/tr-TR.json
+++ b/translations/tr-TR.json
@@ -287,6 +287,7 @@
     },
     "print": {
       "atlasfeature": "",
+      "format": "Format",
       "grid": "Grid",
       "layout": "Yazdırma düzeni",
       "legend": "",

--- a/translations/tsconfig.json
+++ b/translations/tsconfig.json
@@ -241,6 +241,7 @@
     "numericinput.width",
     "numericinput.windowtitle",
     "print.atlasfeature",
+    "print.format",
     "print.grid",
     "print.layout",
     "print.legend",


### PR DESCRIPTION
Hi !

This PR allows user to print layouts with other formats than PDF by selecting PDF, PNG, JPEG or SVG. By default, PDF is selected.

Please let me know if you want to set option configs for available formats and default format. 

Thanks

_This feature has been funded by Grand Lyon Métropole https://www.grandlyon.com/_