### PR TITLE
first steps to specify side parameter in plugins with resizeable windows

### DIFF
--- a/components/ResizeableWindow.jsx
+++ b/components/ResizeableWindow.jsx
@@ -79,14 +79,14 @@ class ResizeableWindow extends React.Component {
         this.dragShield = null;
         this.titlebar = null;
         this.id = uuidv1();
-        const height = Math.min(props.initialHeight, window.innerHeight - 100);
         const width = Math.min(props.initialWidth, window.innerWidth);
+        const height = Math.min(props.initialHeight, window.innerHeight - 100);
         if (WINDOW_GEOMETRIES[props.title]) {
             this.state.geometry = WINDOW_GEOMETRIES[props.title];
         } else {
             this.state.geometry = {
                 x: props.initialX !== null ? this.computeInitialX(props.initialX) : Math.max(0, Math.round(0.5 * (window.innerWidth - width))),
-                y: props.initialY !== null ? this.computeInitialY(props.initialY) : Math.max(0, Math.round(0.5 * (window.innerHeight - height))),
+                y: props.initialY !== null ? this.computeInitialY(props.initialY) : Math.max(0, Math.round(0.5 * (window.innerHeight - height - 100))),
                 width: width,
                 height: height,
                 docked: false
@@ -102,10 +102,18 @@ class ResizeableWindow extends React.Component {
         }
     }
     computeInitialX = (x) => {
-        return x >= 0 ? x : window.innerWidth - Math.abs(x);
+        if (this.props.dockable == "right") {
+            return x > 0 ? x : window.innerWidth - this.props.initialWidth - Math.abs(x);
+        } else {
+            return x >= 0 ? x : window.innerWidth - this.props.initialWidth - Math.abs(x);
+        }
     };
     computeInitialY = (y) => {
-        return y >= 0 ? y : window.innerHeight - Math.abs(y);
+        if (this.props.dockable == "bottom") {
+            return y > 0 ? y : window.innerHeight - this.props.initialHeight - Math.abs(y) - 100;
+        } else {
+            return y >= 0 ? y : window.innerHeight - this.props.initialHeight - Math.abs(y) - 100;
+        }
     };
     componentDidMount() {
         this.props.registerWindow(this.id);

--- a/plugins/Cyclomedia.jsx
+++ b/plugins/Cyclomedia.jsx
@@ -9,14 +9,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import {addLayer, addLayerFeatures, changeLayerProperty, removeLayer, LayerRole} from 'qwc2/actions/layers';
-import {setCurrentTask} from 'qwc2/actions/task';
-import ResizeableWindow from 'qwc2/components/ResizeableWindow';
-import Spinner from 'qwc2/components/Spinner';
-import CoordinatesUtils from 'qwc2/utils/CoordinatesUtils';
-import LocaleUtils from 'qwc2/utils/LocaleUtils';
+import {addLayer, addLayerFeatures, changeLayerProperty, removeLayer, LayerRole} from '../actions/layers';
+import {setCurrentTask} from '../actions/task';
+import ResizeableWindow from '../components/ResizeableWindow';
+import Spinner from '../components/Spinner';
+import CoordinatesUtils from '../utils/CoordinatesUtils';
+import LocaleUtils from '../utils/LocaleUtils';
 import './style/Cyclomedia.css';
-import MapUtils from 'qwc2/utils/MapUtils';
+import MapUtils from '../utils/MapUtils';
 
 
 const Status = {LOGIN: 0, LOADING: 1, LOADED: 2, ERROR: 3, HAVEPOS: 4};
@@ -39,13 +39,14 @@ class Cyclomedia extends React.Component {
         cyclomediaVersion: PropTypes.string,
         /** Whether to display Cyclomedia measurement geometries on the map. */
         displayMeasurements: PropTypes.bool,
-        /** Default window geometry with size, position and docking status. */
+        /** Default window geometry with size, position and docking status. Positive position values are related to top (InitialY) and left (InitialX), negativ values to bottom (InitialY) and right (InitialX). */
         geometry: PropTypes.shape({
             initialWidth: PropTypes.number,
             initialHeight: PropTypes.number,
             initialX: PropTypes.number,
             initialY: PropTypes.number,
-            initiallyDocked: PropTypes.bool
+            initiallyDocked: PropTypes.bool,
+            side: PropTypes.string
         }),
         /** The relative path to the redirect login handling of oauth. */
         loginRedirectUri: PropTypes.string,
@@ -69,7 +70,8 @@ class Cyclomedia extends React.Component {
             initialHeight: 640,
             initialX: 0,
             initialY: 0,
-            initiallyDocked: false
+            initiallyDocked: false,
+            side: 'left'
         },
         maxMapScale: 10000,
         projection: 'EPSG:3857'
@@ -177,15 +179,11 @@ class Cyclomedia extends React.Component {
         }
         return (
             <ResizeableWindow icon="cyclomedia"
-                initialHeight={this.props.geometry.initialHeight}
-                initialWidth={this.props.geometry.initialWidth}
-                initialX={this.props.geometry.initialX}
-                initialY={this.props.geometry.initialY}
-                initiallyDocked={this.props.geometry.initiallyDocked}
-                onClose={this.onClose}
-                splitScreenWhenDocked
-                title={LocaleUtils.trmsg("cyclomedia.title")}
-            >
+                initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
+                initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
+                initiallyDocked={this.props.geometry.initiallyDocked} dockable={this.props.geometry.side}
+                onClose={this.onClose} splitScreenWhenDocked title={LocaleUtils.trmsg("cyclomedia.title")}
+                >
                 <div className="cyclomedia-body" role="body">
                     {this.props.mapScale > this.props.maxMapScale && this.state.status > Status.LOGIN ? (
                         <div className="cyclomedia-scale-hint">

--- a/plugins/Cyclomedia.jsx
+++ b/plugins/Cyclomedia.jsx
@@ -178,10 +178,10 @@ class Cyclomedia extends React.Component {
             );
         }
         return (
-            <ResizeableWindow icon="cyclomedia"
+            <ResizeableWindow dockable={this.props.geometry.side} icon="cyclomedia"
                 initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
                 initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
-                initiallyDocked={this.props.geometry.initiallyDocked} dockable={this.props.geometry.side}
+                initiallyDocked={this.props.geometry.initiallyDocked}
                 onClose={this.onClose} splitScreenWhenDocked title={LocaleUtils.trmsg("cyclomedia.title")}
                 >
                 <div className="cyclomedia-body" role="body">

--- a/plugins/FeatureForm.jsx
+++ b/plugins/FeatureForm.jsx
@@ -200,11 +200,10 @@ class FeatureForm extends React.Component {
                 );
             }
             resultWindow = (
-                <ResizeableWindow icon="featureform"
+                <ResizeableWindow dockable={this.props.geometry.side} icon="featureform"
                     initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
                     initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
-                    initiallyDocked={this.props.geometry.initiallyDocked} dockable={this.props.geometry.side}
-                    key="FeatureForm"
+                    initiallyDocked={this.props.geometry.initiallyDocked} key="FeatureForm"
                     onClose={this.onWindowClose} title={LocaleUtils.trmsg("featureform.title")}
                     >
                     {body}

--- a/plugins/FeatureForm.jsx
+++ b/plugins/FeatureForm.jsx
@@ -46,13 +46,14 @@ class FeatureForm extends React.Component {
         enabled: PropTypes.bool,
         /** Whether to clear the task when the results window is closed. */
         exitTaskOnResultsClose: PropTypes.bool,
-        /** Default window geometry with size, position and docking status. */
+        /** Default window geometry with size, position and docking status. Positive position values are related to top (InitialY) and left (InitialX), negativ values to bottom (InitialY) and right (InitialX). */
         geometry: PropTypes.shape({
             initialWidth: PropTypes.number,
             initialHeight: PropTypes.number,
             initialX: PropTypes.number,
             initialY: PropTypes.number,
-            initiallyDocked: PropTypes.bool
+            initiallyDocked: PropTypes.bool,
+            side: PropTypes.string
         }),
         iface: PropTypes.object,
         layers: PropTypes.array,
@@ -67,7 +68,8 @@ class FeatureForm extends React.Component {
             initialHeight: 480,
             initialX: 0,
             initialY: 0,
-            initiallyDocked: false
+            initiallyDocked: false,
+            side: 'left'
         }
     };
     static defaultState = {
@@ -201,9 +203,10 @@ class FeatureForm extends React.Component {
                 <ResizeableWindow icon="featureform"
                     initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
                     initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
-                    initiallyDocked={this.props.geometry.initiallyDocked} key="FeatureForm"
+                    initiallyDocked={this.props.geometry.initiallyDocked} dockable={this.props.geometry.side}
+                    key="FeatureForm"
                     onClose={this.onWindowClose} title={LocaleUtils.trmsg("featureform.title")}
-                >
+                    >
                     {body}
                 </ResizeableWindow>
             );

--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -60,13 +60,14 @@ class Identify extends React.Component {
         exitTaskOnResultsClose: PropTypes.bool,
         /** Whether to assume that XML GetFeatureInfo responses specify the technical layer name in the `name` attribute, rather than the layer title. */
         featureInfoReturnsLayerName: PropTypes.bool,
-        /** Default window geometry with size, position and docking status. */
+        /** Default window geometry with size, position and docking status. Positive position values are related to top (InitialY) and left (InitialX), negativ values to bottom (InitialY) and right (InitialX). */
         geometry: PropTypes.shape({
             initialWidth: PropTypes.number,
             initialHeight: PropTypes.number,
             initialX: PropTypes.number,
             initialY: PropTypes.number,
-            initiallyDocked: PropTypes.bool
+            initiallyDocked: PropTypes.bool,
+            side: PropTypes.string
         }),
         iframeDialogsInitiallyDocked: PropTypes.bool,
         /** The initial radius of the identify dialog in radius mode. */
@@ -97,7 +98,8 @@ class Identify extends React.Component {
             initialHeight: 320,
             initialX: 0,
             initialY: 0,
-            initiallyDocked: false
+            initiallyDocked: false,
+            side: 'left'
         },
         initialRadius: 50,
         initialRadiusUnits: 'meters'
@@ -398,10 +400,10 @@ class Identify extends React.Component {
             resultWindow = (
                 <ResizeableWindow icon="info-sign"
                     initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
-                    initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY} initiallyDocked={this.props.geometry.initiallyDocked}
-                    key="IdentifyWindow"
+                    initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
+                    initiallyDocked={this.props.geometry.initiallyDocked} dockable={this.props.geometry.side} key="IdentifyWindow"
                     onClose={this.onWindowClose} title={LocaleUtils.trmsg("identify.title")}
-                >
+                    >
                     {body}
                 </ResizeableWindow>
             );

--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -398,10 +398,10 @@ class Identify extends React.Component {
                 );
             }
             resultWindow = (
-                <ResizeableWindow icon="info-sign"
+                <ResizeableWindow dockable={this.props.geometry.side} icon="info-sign"
                     initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
                     initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
-                    initiallyDocked={this.props.geometry.initiallyDocked} dockable={this.props.geometry.side} key="IdentifyWindow"
+                    initiallyDocked={this.props.geometry.initiallyDocked} key="IdentifyWindow"
                     onClose={this.onWindowClose} title={LocaleUtils.trmsg("identify.title")}
                     >
                     {body}

--- a/plugins/LayerCatalog.jsx
+++ b/plugins/LayerCatalog.jsx
@@ -100,10 +100,10 @@ class LayerCatalog extends React.Component {
             return null;
         }
         return (
-            <ResizeableWindow icon="catalog"
+            <ResizeableWindow dockable={this.props.geometry.side} icon="catalog"
                 initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
                 initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
-                initiallyDocked={this.props.geometry.initiallyDocked} dockable={this.props.geometry.side}
+                initiallyDocked={this.props.geometry.initiallyDocked}
                 onClose={this.onClose} title={LocaleUtils.trmsg("layercatalog.windowtitle")}
                 >
                 <div className="layer-catalog" role="body">

--- a/plugins/LayerCatalog.jsx
+++ b/plugins/LayerCatalog.jsx
@@ -56,13 +56,14 @@ class LayerCatalog extends React.Component {
         active: PropTypes.bool,
         /** The URL to the catalog JSON file. */
         catalogUrl: PropTypes.string,
-        /** Default window geometry with size, position and docking status. */
+        /** Default window geometry with size, position and docking status. Positive position values are related to top (InitialY) and left (InitialX), negativ values to bottom (InitialY) and right (InitialX). */
         geometry: PropTypes.shape({
             initialWidth: PropTypes.number,
             initialHeight: PropTypes.number,
             initialX: PropTypes.number,
             initialY: PropTypes.number,
-            initiallyDocked: PropTypes.bool
+            initiallyDocked: PropTypes.bool,
+            side: PropTypes.string
         }),
         setCurrentTask: PropTypes.func
     };
@@ -72,7 +73,8 @@ class LayerCatalog extends React.Component {
             initialHeight: 320,
             initialX: 0,
             initialY: 0,
-            initiallyDocked: false
+            initiallyDocked: false,
+            side: 'left'
         }
     };
     state = {
@@ -98,9 +100,12 @@ class LayerCatalog extends React.Component {
             return null;
         }
         return (
-            <ResizeableWindow icon="catalog" initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
-                initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY} initiallyDocked={this.props.geometry.initiallyDocked}
-                onClose={this.onClose} title={LocaleUtils.trmsg("layercatalog.windowtitle")} >
+            <ResizeableWindow icon="catalog"
+                initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
+                initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
+                initiallyDocked={this.props.geometry.initiallyDocked} dockable={this.props.geometry.side}
+                onClose={this.onClose} title={LocaleUtils.trmsg("layercatalog.windowtitle")}
+                >
                 <div className="layer-catalog" role="body">
                     <LayerCatalogWidget catalog={this.state.catalog} pendingRequests={0} />
                 </div>

--- a/plugins/MapLegend.jsx
+++ b/plugins/MapLegend.jsx
@@ -97,10 +97,10 @@ class MapLegend extends React.Component {
         ];
 
         return (
-            <ResizeableWindow extraControls={extraControls} icon="list-alt"
+            <ResizeableWindow dockable={this.props.geometry.side} extraControls={extraControls} icon="list-alt"
                 initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
                 initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
-                initiallyDocked={this.props.geometry.initiallyDocked} dockable={this.props.geometry.side}
+                initiallyDocked={this.props.geometry.initiallyDocked}
                 onClose={this.onClose} title={LocaleUtils.trmsg("maplegend.windowtitle")}
                 >
                 <div className="map-legend" role="body">

--- a/plugins/MapLegend.jsx
+++ b/plugins/MapLegend.jsx
@@ -34,13 +34,14 @@ class MapLegend extends React.Component {
         bboxDependentLegend: PropTypes.bool,
         /** Extra parameters to add to the GetLegendGraphics request. */
         extraLegendParameters: PropTypes.string,
-        /** Default window geometry with size, position and docking status. */
+        /** Default window geometry with size, position and docking status. Positive position values are related to top (InitialY) and left (InitialX), negativ values to bottom (InitialY) and right (InitialX). */
         geometry: PropTypes.shape({
             initialWidth: PropTypes.number,
             initialHeight: PropTypes.number,
             initialX: PropTypes.number,
             initialY: PropTypes.number,
-            initiallyDocked: PropTypes.bool
+            initiallyDocked: PropTypes.bool,
+            side: PropTypes.string
         }),
         layers: PropTypes.array,
         map: PropTypes.object,
@@ -61,7 +62,8 @@ class MapLegend extends React.Component {
             initialHeight: 320,
             initialX: 0,
             initialY: 0,
-            initiallyDocked: false
+            initiallyDocked: false,
+            side: 'left'
         }
     };
     state = {
@@ -95,9 +97,12 @@ class MapLegend extends React.Component {
         ];
 
         return (
-            <ResizeableWindow extraControls={extraControls} icon="list-alt" initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
+            <ResizeableWindow extraControls={extraControls} icon="list-alt"
+                initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
                 initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
-                initiallyDocked={this.props.geometry.initiallyDocked} onClose={this.onClose} title={LocaleUtils.trmsg("maplegend.windowtitle")} >
+                initiallyDocked={this.props.geometry.initiallyDocked} dockable={this.props.geometry.side}
+                onClose={this.onClose} title={LocaleUtils.trmsg("maplegend.windowtitle")}
+                >
                 <div className="map-legend" role="body">
                     {this.props.layers.map(layer => {
                         if (this.state.onlyVisibleLegend && !layer.visibility) {

--- a/plugins/Routing.jsx
+++ b/plugins/Routing.jsx
@@ -239,10 +239,10 @@ class Routing extends React.Component {
         ];
         const enabledButtons = this.props.enabledModes.map(entry => buttons.find(button => button.key === entry));
         return (
-            <ResizeableWindow icon="routing"
+            <ResizeableWindow dockable={this.props.geometry.side} icon="routing"
                 initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
                 initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
-                initiallyDocked={this.props.geometry.initiallyDocked} dockable={this.props.geometry.side}
+                initiallyDocked={this.props.geometry.initiallyDocked}
                 onClose={() => this.setState({visible: false})} title={LocaleUtils.tr("routing.windowtitle")}
                 >
                 <div className="routing-body" role="body">

--- a/plugins/Routing.jsx
+++ b/plugins/Routing.jsx
@@ -48,13 +48,14 @@ class Routing extends React.Component {
         enabledModes: PropTypes.arrayOf(PropTypes.string),
         /** List of search providers to use for routing location search. */
         enabledProviders: PropTypes.arrayOf(PropTypes.string),
-        /** Default window geometry with size, position and docking status. */
+        /** Default window geometry with size, position and docking status. Positive position values are related to top (InitialY) and left (InitialX), negativ values to bottom (InitialY) and right (InitialX). */
         geometry: PropTypes.shape({
             initialWidth: PropTypes.number,
             initialHeight: PropTypes.number,
             initialX: PropTypes.number,
             initialY: PropTypes.number,
-            initiallyDocked: PropTypes.bool
+            initiallyDocked: PropTypes.bool,
+            side: PropTypes.string
         }),
         layers: PropTypes.array,
         locatePos: PropTypes.array,
@@ -74,7 +75,8 @@ class Routing extends React.Component {
             initialHeight: 640,
             initialX: 0,
             initialY: 0,
-            initiallyDocked: true
+            initiallyDocked: true,
+            side: 'left'
         }
     };
     state = {
@@ -237,7 +239,12 @@ class Routing extends React.Component {
         ];
         const enabledButtons = this.props.enabledModes.map(entry => buttons.find(button => button.key === entry));
         return (
-            <ResizeableWindow icon="routing" onClose={() => this.setState({visible: false})} title={LocaleUtils.tr("routing.windowtitle")} {...this.props.geometry}>
+            <ResizeableWindow icon="routing"
+                initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
+                initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
+                initiallyDocked={this.props.geometry.initiallyDocked} dockable={this.props.geometry.side}
+                onClose={() => this.setState({visible: false})} title={LocaleUtils.tr("routing.windowtitle")}
+                >
                 <div className="routing-body" role="body">
                     <ButtonBar active={this.state.currentTab} buttons={tabButtons} className="routing-buttonbar" onClick={(key) => this.setState({currentTab: key})} />
                     <div className="routing-frame">

--- a/plugins/TimeManager.jsx
+++ b/plugins/TimeManager.jsx
@@ -312,9 +312,10 @@ class TimeManager extends React.Component {
             body = this.renderBody(timeValues);
         }
         return (
-            <ResizeableWindow dockable="bottom"  icon="clock" initialHeight={this.props.geometry.initialHeight}
-                initialWidth={this.props.geometry.initialWidth} initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
-                initiallyDocked={this.props.geometry.initiallyDocked} onClose={this.onClose} onGeometryChanged={this.dialogGeomChanged}
+            <ResizeableWindow icon="clock"
+                initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth} initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
+                initiallyDocked={this.props.geometry.initiallyDocked} dockable="bottom"
+                onClose={this.onClose} onGeometryChanged={this.dialogGeomChanged}
                 scrollable splitScreenWhenDocked title={LocaleUtils.tr("timemanager.title")}>
                 {body}
             </ResizeableWindow>

--- a/plugins/TimeManager.jsx
+++ b/plugins/TimeManager.jsx
@@ -312,9 +312,10 @@ class TimeManager extends React.Component {
             body = this.renderBody(timeValues);
         }
         return (
-            <ResizeableWindow icon="clock"
-                initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth} initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
-                initiallyDocked={this.props.geometry.initiallyDocked} dockable="bottom"
+            <ResizeableWindow dockable="bottom" icon="clock"
+                initialHeight={this.props.geometry.initialHeight} initialWidth={this.props.geometry.initialWidth}
+                initialX={this.props.geometry.initialX} initialY={this.props.geometry.initialY}
+                initiallyDocked={this.props.geometry.initiallyDocked}
                 onClose={this.onClose} onGeometryChanged={this.dialogGeomChanged}
                 scrollable splitScreenWhenDocked title={LocaleUtils.tr("timemanager.title")}>
                 {body}


### PR DESCRIPTION
In the end this should solve https://github.com/qgis/qwc2-demo-app/issues/510.

I've implemented the required parameters within the respective plugins and updated the resizeableWindow component, so the initial position of the window is different in relation to the docking side.

The initial position can now be set in relation to each side, where positive position values are related to top (InitialY) and left (InitialX) and negativ values to bottom (InitialY) and right (InitialX).

One thing is missing, where I could need some help/hints for implementation. Until now there is a fixed value of `100` to compensate the height of top bar and bottom bar. It would be very nice to get the exact height of these and calculate the height and position of the window in relation to this.
So everytime there is
```
- 100
```
It should be something like
```
- (topBarHeight + bottombarHeight)
```
But how can I get these? I've tried to get something using the _effect hook_ with `useState` and `useEffect`, but didn't come to working solution. Maybe you have an approach for this? Thanks in advance!