### PR TITLE
Store bottombar height in state

### DIFF
--- a/actions/map.js
+++ b/actions/map.js
@@ -21,6 +21,7 @@ export const ZOOM_TO_POINT = 'ZOOM_TO_POINT';
 export const CHANGE_ROTATION = 'CHANGE_ROTATION';
 export const TOGGLE_MAPTIPS = 'TOGGLE_MAPTIPS';
 export const SET_TOPBAR_HEIGHT = 'SET_TOPBAR_HEIGHT';
+export const SET_BOTTOMBAR_HEIGHT = 'SET_BOTTOMBAR_HEIGHT';
 export const SET_SNAPPING_CONFIG = 'SET_SNAPPING_CONFIG';
 
 export function changeMapView(center, zoom, bbox, size, mapStateSource, projection) {
@@ -110,6 +111,13 @@ export function toggleMapTips(active) {
 export function setTopbarHeight(height) {
     return {
         type: SET_TOPBAR_HEIGHT,
+        height
+    };
+}
+
+export function setBottombarHeight(height) {
+    return {
+        type: SET_BOTTOMBAR_HEIGHT,
         height
     };
 }

--- a/plugins/BottomBar.jsx
+++ b/plugins/BottomBar.jsx
@@ -12,7 +12,7 @@ import {connect} from 'react-redux';
 import {createSelector} from 'reselect';
 import pickBy from 'lodash.pickby';
 import {changeMousePositionState} from '../actions/mousePosition';
-import {changeZoomLevel} from '../actions/map';
+import {changeZoomLevel, setBottombarHeight} from '../actions/map';
 import {openExternalUrl} from '../actions/task';
 import {showIframeDialog} from '../actions/windows';
 import CoordinateDisplayer from '../components/CoordinateDisplayer';
@@ -40,6 +40,7 @@ class BottomBar extends React.Component {
         fullscreen: PropTypes.bool,
         map: PropTypes.object,
         openExternalUrl: PropTypes.func,
+        setBottombarHeight: PropTypes.func,
         showIframeDialog: PropTypes.func,
         /** The URL of the terms label anchor. */
         termsUrl: PropTypes.string,
@@ -146,7 +147,7 @@ class BottomBar extends React.Component {
         }
 
         return (
-            <div id="BottomBar">
+            <div id="BottomBar" ref={this.storeHeight}>
                 <span className="bottombar-spacer" />
                 {coordinates}
                 {scales}
@@ -172,6 +173,11 @@ class BottomBar extends React.Component {
             this.props.changeZoomLevel(this.props.map.zoom);
         }
     };
+    storeHeight = (el) => {
+        if (el) {
+            this.props.setBottombarHeight(el.clientHeight);
+        }
+    };
 }
 
 const selector = createSelector([state => state, displayCrsSelector], (state, displaycrs) => {
@@ -187,5 +193,6 @@ export default connect(selector, {
     changeMousePositionState: changeMousePositionState,
     changeZoomLevel: changeZoomLevel,
     openExternalUrl: openExternalUrl,
+    setBottombarHeight: setBottombarHeight,
     showIframeDialog: showIframeDialog
 })(BottomBar);

--- a/reducers/map.js
+++ b/reducers/map.js
@@ -9,7 +9,7 @@
 
 import {
     CHANGE_MAP_VIEW, CONFIGURE_MAP, CHANGE_ZOOM_LVL, ZOOM_TO_EXTENT, ZOOM_TO_POINT,
-    PAN_TO, CHANGE_ROTATION, CLICK_ON_MAP, TOGGLE_MAPTIPS, SET_TOPBAR_HEIGHT, SET_SNAPPING_CONFIG
+    PAN_TO, CHANGE_ROTATION, CLICK_ON_MAP, TOGGLE_MAPTIPS, SET_TOPBAR_HEIGHT, SET_BOTTOMBAR_HEIGHT, SET_SNAPPING_CONFIG
 } from '../actions/map';
 import isEmpty from 'lodash.isempty';
 import MapUtils from '../utils/MapUtils';
@@ -26,6 +26,7 @@ const defaultState = {
     scales: [0],
     resolutions: [0],
     topbarHeight: 0,
+    bottombarHeight: 0,
     click: null,
     snapping: {
         enabled: false,
@@ -135,6 +136,9 @@ export default function map(state = defaultState, action) {
     }
     case SET_TOPBAR_HEIGHT: {
         return {...state, topbarHeight: action.height};
+    }
+    case SET_BOTTOMBAR_HEIGHT: {
+        return {...state, bottombarHeight: action.height};
     }
     case SET_SNAPPING_CONFIG: {
         return {...state, snapping: {enabled: action.enabled, active: action.active}};


### PR DESCRIPTION
I needed the height of the bottombar for a custom plugin. Similar to the topbar, I added the storing of the bottombar height in state. Maybe this is also useful for other users.