### PR TITLE
Fix typo

### DIFF
--- a/plugins/map/RedliningPickSupport.jsx
+++ b/plugins/map/RedliningPickSupport.jsx
@@ -28,7 +28,7 @@ class RedliningPickSupport extends React.Component {
         this.selectedFeatures = [];
         const geometryFunction = (feature) => {
             if (feature.getGeometry().getType() === "Point") {
-                return new ol.geom.MultiPoint([f.getGeometry().getCoordinates()]);
+                return new ol.geom.MultiPoint([feature.getGeometry().getCoordinates()]);
             } else if (feature.getGeometry().getType() === "LineString") {
                 return new ol.geom.MultiPoint(feature.getGeometry().getCoordinates());
             }


### PR DESCRIPTION
Probably fixes a typo because the variable f is not existing.