### PR TITLE
Remove css property without value

### DIFF
--- a/components/timeline/style/FixedTimeline.css
+++ b/components/timeline/style/FixedTimeline.css
@@ -9,7 +9,6 @@ div.fixtimeline {
 div.fixtimeline-toolbar {
     display: flex;
     font-size: 70%;
-    padding-top: 
 }
 
 div.fixtimeline-toolbar-spacer {


### PR DESCRIPTION
There is no value assigned to the css `padding-top` property.