### PR TITLE
Add declutter option to MVT

### DIFF
--- a/components/map/layers/MVTLayer.js
+++ b/components/map/layers/MVTLayer.js
@@ -14,6 +14,7 @@ export default {
         const layer = new ol.layer.VectorTile({
             minResolution: options.minResolution,
             maxResolution: options.maxResolution,
+            declutter: options.declutter,
             source: new ol.source.VectorTile({
                 projection: options.projection,
                 format: new ol.format.MVT({}),


### PR DESCRIPTION
I would like to submit this PR in order to add a config option to enable declutter or not. 
Not using declutter with a tilegrid may result to cropped and stacked labels. 

Example without declutter : 
Labels got stacked on each other
![image](https://github.com/qgis/qwc2/assets/92778930/2b29059a-0ec0-4edf-91e3-0bdd4e2995f4)
Labels got cropped at certain scales 
![image](https://github.com/qgis/qwc2/assets/92778930/7aac81a2-3f5d-4ba8-9983-343ebf677b40)



Example with declutter : 
City name under roads do not load, as intended and labels are rendered properly 
![image](https://github.com/qgis/qwc2/assets/92778930/18cf58c9-1ef6-46cd-8015-d15d67d9b7c4)
Labels are not cropped anymore
![image](https://github.com/qgis/qwc2/assets/92778930/1dac9da5-d254-4bd9-b7db-5e1d49a0fb89)


Let me know if it's ok for you or not. A modification in the documentation will be needed as well if it's ok.
Thanks in advance, 
Kind regards, Clément. 
