### PR TITLE
csv+zip export from IdentifyViewer

### DIFF
--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -113,8 +113,10 @@ const BuiltinExporters = [
                     csv += '\n';
                 }
                 features.forEach(feature => {
-                    Object.values(feature.properties || {}).forEach((value) => {
-                        csv += String(value).replace('"', '""') + ';';
+                    Object.entries(feature.properties || {}).forEach(([attrib, value]) => {
+                        if (attrib !== "htmlContent" && attrib !== "htmlContentInline") {
+                            csv += String(value).replace('"', '""') + ';';
+                        }
                     });
                     if (feature.geometry) {
                         csv += VectorLayerUtils.geoJSONGeomToWkt(feature.geometry);


### PR DESCRIPTION
see also https://github.com/qwc-services/qwc-docker/issues/73 

This will exclude the html formatted content (examples below) from the export file and the result can be opened correct in excel.
```
<table class=""attribute-list">	
    <tbody>	
    	
            <tr>	
                <td class="identify-attr-title wrap">	
                    <i>featurecla</i>	
                </td>	
                <td class="identify-attr-value wrap">	
                    Admin-0 country	
                </td>	
            </tr>	
            <tr>	
                <td class="identify-attr-title wrap">	
                    <i>sovereignt</i>	
                </td>	
                <td class="identify-attr-value wrap">	
                    Ethiopia	
                </td>	
```
 ```
   <table class=""attribute-list">
        <tbody>
        
                <tr>
                    <td class="identify-attr-title wrap">
                        <i>name</i>
                    </td>
                    <td class="identify-attr-value wrap">
...
```