### PR TITLE
Add option for the indent size behavior in layer catalog

### DIFF
--- a/components/widgets/LayerCatalogWidget.jsx
+++ b/components/widgets/LayerCatalogWidget.jsx
@@ -15,6 +15,7 @@ class LayerCatalogWidget extends React.PureComponent {
     static propTypes = {
         addLayer: PropTypes.func,
         catalog: PropTypes.array,
+        levelBasedIndentSize: PropTypes.bool,
         mapCrs: PropTypes.string,
         pendingRequests: PropTypes.number
     };
@@ -39,8 +40,9 @@ class LayerCatalogWidget extends React.PureComponent {
         }
         const type = entry.resource ? entry.resource.slice(0, entry.resource.indexOf(":")) : entry.type;
         const key = (entry.resource || (entry.type + ":" + entry.name)) + ":" + idx;
+        const indentSize = !this.props.levelBasedIndentSize && level > 0 ? 1.5 : level;
         return (
-            <div key={key} style={{paddingLeft: level + 'em'}}>
+            <div key={key} style={{paddingLeft: indentSize + 'em'}}>
                 <div className="layer-catalog-widget-entry">
                     {hasSublayers ? (<Icon icon={entry.expanded ? 'tree_minus' : 'tree_plus'} onClick={() => this.toggleLayerListEntry(path)} />) : null}
                     <span onClick={() => type ? this.addServiceLayer(entry) : this.toggleLayerListEntry(path)}>

--- a/plugins/LayerCatalog.jsx
+++ b/plugins/LayerCatalog.jsx
@@ -65,6 +65,8 @@ class LayerCatalog extends React.Component {
             initiallyDocked: PropTypes.bool,
             side: PropTypes.string
         }),
+        /** Whether to increase the indent size dynamically according to the current level (`true`) or keep the indent size constant (`false`). */
+        levelBasedIndentSize: PropTypes.bool,
         setCurrentTask: PropTypes.func
     };
     static defaultProps = {
@@ -75,7 +77,8 @@ class LayerCatalog extends React.Component {
             initialY: 0,
             initiallyDocked: false,
             side: 'left'
-        }
+        },
+        levelBasedIndentSize: true
     };
     state = {
         catalog: null
@@ -107,7 +110,7 @@ class LayerCatalog extends React.Component {
                 onClose={this.onClose} title={LocaleUtils.trmsg("layercatalog.windowtitle")}
                 >
                 <div className="layer-catalog" role="body">
-                    <LayerCatalogWidget catalog={this.state.catalog} pendingRequests={0} />
+                    <LayerCatalogWidget catalog={this.state.catalog} levelBasedIndentSize={this.props.levelBasedIndentSize} pendingRequests={0} />
                 </div>
             </ResizeableWindow>
         );


### PR DESCRIPTION
With many subgroups in the layer catalog, the level based indent size becomes relatively large. So I added an option for a variant with a constant indent size.