### PR TITLE
Add support for complex "iframedialog" strings as target to the TopBar/BottomBar

### DIFF
--- a/components/AppMenu.jsx
+++ b/components/AppMenu.jsx
@@ -193,7 +193,7 @@ class AppMenu extends React.Component {
             this.toggleMenu();
         }
         if (item.url) {
-            this.props.openExternalUrl(item.url, item.target, LocaleUtils.tr("appmenu.items." + item.key), {icon: item.icon, ...(item.iframeOptions || {})});
+            this.props.openExternalUrl(item.url, item.target, LocaleUtils.tr("appmenu.items." + item.key), item.icon);
         } else {
             this.props.setCurrentTask(item.task || item.key, item.mode, item.mapClickAction || (item.identifyEnabled ? "identify" : null));
         }

--- a/components/AppMenu.jsx
+++ b/components/AppMenu.jsx
@@ -193,7 +193,7 @@ class AppMenu extends React.Component {
             this.toggleMenu();
         }
         if (item.url) {
-            this.props.openExternalUrl(item.url, item.target, LocaleUtils.tr("appmenu.items." + item.key), item.icon);
+            this.props.openExternalUrl(item.url, item.target, LocaleUtils.tr("appmenu.items." + item.key), {icon: item.icon, ...(item.iframeOptions || {})});
         } else {
             this.props.setCurrentTask(item.task || item.key, item.mode, item.mapClickAction || (item.identifyEnabled ? "identify" : null));
         }

--- a/components/Toolbar.jsx
+++ b/components/Toolbar.jsx
@@ -82,7 +82,7 @@ class Toolbar extends React.Component {
     };
     itemClicked = (item, active) => {
         if (item.url) {
-            this.props.openExternalUrl(item.url, item.target, LocaleUtils.tr("appmenu.items." + item.key), {icon: item.icon, ...(item.iframeOptions || {})});
+            this.props.openExternalUrl(item.url, item.target, LocaleUtils.tr("appmenu.items." + item.key));
         } else if (active) {
             this.props.setCurrentTask(null);
         } else {

--- a/components/Toolbar.jsx
+++ b/components/Toolbar.jsx
@@ -82,7 +82,7 @@ class Toolbar extends React.Component {
     };
     itemClicked = (item, active) => {
         if (item.url) {
-            this.props.openExternalUrl(item.url, item.target, LocaleUtils.tr("appmenu.items." + item.key));
+            this.props.openExternalUrl(item.url, item.target, LocaleUtils.tr("appmenu.items." + item.key), {icon: item.icon, ...(item.iframeOptions || {})});
         } else if (active) {
             this.props.setCurrentTask(null);
         } else {

--- a/components/Toolbar.jsx
+++ b/components/Toolbar.jsx
@@ -82,7 +82,7 @@ class Toolbar extends React.Component {
     };
     itemClicked = (item, active) => {
         if (item.url) {
-            this.props.openExternalUrl(item.url, item.target, LocaleUtils.tr("appmenu.items." + item.key));
+            this.props.openExternalUrl(item.url, item.target, LocaleUtils.tr("appmenu.items." + item.key), item.icon);
         } else if (active) {
             this.props.setCurrentTask(null);
         } else {

--- a/plugins/BottomBar.jsx
+++ b/plugins/BottomBar.jsx
@@ -158,7 +158,22 @@ class BottomBar extends React.Component {
     }
     openUrl = (ev, url, target, title, icon) => {
         ev.preventDefault();
-        if (target === "iframe") {
+        if (target.startsWith(":")) {
+            const targetParts = target.split(":");
+            const options = targetParts.slice(2).reduce((res, cur) => {
+                const parts = cur.split("=");
+                if (parts.length === 2) {
+                    const value = parseFloat(parts[1]);
+                    res[parts[0]] = isNaN(value) ? parts[1] : value;
+                }
+                return res;
+            }, {});
+            if (targetParts[1] === "iframedialog") {
+                this.props.showIframeDialog(targetParts[2], url, {title: title, icon: icon, ...options});
+            } else {
+                this.props.openExternalUrl(url);
+            }
+        } else if (target === "iframe") {
             this.props.showIframeDialog("externallinkiframe", url, {title: title, icon: icon});
         } else {
             this.props.openExternalUrl(url);

--- a/plugins/BottomBar.jsx
+++ b/plugins/BottomBar.jsx
@@ -46,16 +46,12 @@ class BottomBar extends React.Component {
         termsUrl: PropTypes.string,
         /** Icon of the terms inline window. Relevant only when `termsUrlTarget` is `iframe`. */
         termsUrlIcon: PropTypes.string,
-        /** Options of the terms inline window. Relevant only when `termsUrlTarget` is `iframe`. */
-        termsUrlOptions: PropTypes.object,
         /** The target where to open the terms URL. If `iframe`, it will be displayed in an inline window, otherwise in a new tab. */
         termsUrlTarget: PropTypes.string,
         /** The URL of the viewer title label anchor. */
         viewertitleUrl: PropTypes.string,
         /** Icon of the viewer title inline window. Relevant only when `viewertitleUrl` is `iframe`. */
         viewertitleUrlIcon: PropTypes.string,
-        /** Options of the viewer title inline window. Relevant only when `viewertitleUrl` is `iframe`. */
-        viewertitleUrlOptions: PropTypes.object,
         /** The target where to open the viewer title URL. If `iframe`, it will be displayed in an inline window, otherwise in a new tab. */
         viewertitleUrlTarget: PropTypes.string
     };
@@ -85,7 +81,7 @@ class BottomBar extends React.Component {
         let viewertitleLink;
         if (this.props.viewertitleUrl) {
             viewertitleLink = (
-                <a href={this.props.viewertitleUrl} onClick={(ev) => this.openUrl(ev, this.props.viewertitleUrl, this.props.viewertitleUrlTarget, LocaleUtils.tr("bottombar.viewertitle_label"), {icon: this.props.viewertitleUrlIcon, ...(this.props.viewertitleUrlOptions || {})})}>
+                <a href={this.props.viewertitleUrl} onClick={(ev) => this.openUrl(ev, this.props.viewertitleUrl, this.props.viewertitleUrlTarget, LocaleUtils.tr("bottombar.viewertitle_label"), this.props.viewertitleUrlIcon)}>
                     <span className="viewertitle_label">{LocaleUtils.tr("bottombar.viewertitle_label")}</span>
                 </a>
             );
@@ -93,7 +89,7 @@ class BottomBar extends React.Component {
         let termsLink;
         if (this.props.termsUrl) {
             termsLink = (
-                <a href={this.props.termsUrl} onClick={(ev) => this.openUrl(ev, this.props.termsUrl, this.props.termsUrlTarget, LocaleUtils.tr("bottombar.terms_label"), {icon: this.props.termsUrlIcon, ...(this.props.termsUrlOptions || {})})}>
+                <a href={this.props.termsUrl} onClick={(ev) => this.openUrl(ev, this.props.termsUrl, this.props.termsUrlTarget, LocaleUtils.tr("bottombar.terms_label"), this.props.termsUrlIcon)}>
                     <span className="terms_label">{LocaleUtils.tr("bottombar.terms_label")}</span>
                 </a>
             );
@@ -160,10 +156,10 @@ class BottomBar extends React.Component {
             </div>
         );
     }
-    openUrl = (ev, url, target, title, options) => {
+    openUrl = (ev, url, target, title, icon) => {
         ev.preventDefault();
         if (target === "iframe") {
-            this.props.showIframeDialog("externallinkiframe", url, {title: title, ...options});
+            this.props.showIframeDialog("externallinkiframe", url, {title: title, icon: icon});
         } else {
             this.props.openExternalUrl(url);
         }

--- a/plugins/BottomBar.jsx
+++ b/plugins/BottomBar.jsx
@@ -46,12 +46,16 @@ class BottomBar extends React.Component {
         termsUrl: PropTypes.string,
         /** Icon of the terms inline window. Relevant only when `termsUrlTarget` is `iframe`. */
         termsUrlIcon: PropTypes.string,
+        /** Options of the terms inline window. Relevant only when `termsUrlTarget` is `iframe`. */
+        termsUrlOptions: PropTypes.object,
         /** The target where to open the terms URL. If `iframe`, it will be displayed in an inline window, otherwise in a new tab. */
         termsUrlTarget: PropTypes.string,
         /** The URL of the viewer title label anchor. */
         viewertitleUrl: PropTypes.string,
         /** Icon of the viewer title inline window. Relevant only when `viewertitleUrl` is `iframe`. */
         viewertitleUrlIcon: PropTypes.string,
+        /** Options of the viewer title inline window. Relevant only when `viewertitleUrl` is `iframe`. */
+        viewertitleUrlOptions: PropTypes.object,
         /** The target where to open the viewer title URL. If `iframe`, it will be displayed in an inline window, otherwise in a new tab. */
         viewertitleUrlTarget: PropTypes.string
     };
@@ -81,7 +85,7 @@ class BottomBar extends React.Component {
         let viewertitleLink;
         if (this.props.viewertitleUrl) {
             viewertitleLink = (
-                <a href={this.props.viewertitleUrl} onClick={(ev) => this.openUrl(ev, this.props.viewertitleUrl, this.props.viewertitleUrlTarget, LocaleUtils.tr("bottombar.viewertitle_label"), this.props.viewertitleUrlIcon)}>
+                <a href={this.props.viewertitleUrl} onClick={(ev) => this.openUrl(ev, this.props.viewertitleUrl, this.props.viewertitleUrlTarget, LocaleUtils.tr("bottombar.viewertitle_label"), {icon: this.props.viewertitleUrlIcon, ...(this.props.viewertitleUrlOptions || {})})}>
                     <span className="viewertitle_label">{LocaleUtils.tr("bottombar.viewertitle_label")}</span>
                 </a>
             );
@@ -89,7 +93,7 @@ class BottomBar extends React.Component {
         let termsLink;
         if (this.props.termsUrl) {
             termsLink = (
-                <a href={this.props.termsUrl} onClick={(ev) => this.openUrl(ev, this.props.termsUrl, this.props.termsUrlTarget, LocaleUtils.tr("bottombar.terms_label"), this.props.termsUrlIcon)}>
+                <a href={this.props.termsUrl} onClick={(ev) => this.openUrl(ev, this.props.termsUrl, this.props.termsUrlTarget, LocaleUtils.tr("bottombar.terms_label"), {icon: this.props.termsUrlIcon, ...(this.props.termsUrlOptions || {})})}>
                     <span className="terms_label">{LocaleUtils.tr("bottombar.terms_label")}</span>
                 </a>
             );
@@ -156,10 +160,10 @@ class BottomBar extends React.Component {
             </div>
         );
     }
-    openUrl = (ev, url, target, title, icon) => {
+    openUrl = (ev, url, target, title, options) => {
         ev.preventDefault();
         if (target === "iframe") {
-            this.props.showIframeDialog("externallinkiframe", url, {title: title, icon: icon});
+            this.props.showIframeDialog("externallinkiframe", url, {title: title, ...options});
         } else {
             this.props.openExternalUrl(url);
         }

--- a/plugins/TopBar.jsx
+++ b/plugins/TopBar.jsx
@@ -161,7 +161,22 @@ class TopBar extends React.Component {
         );
     }
     openUrl = (url, target, title, icon) => {
-        if (target === "iframe") {
+        if (target.startsWith(":")) {
+            const targetParts = target.split(":");
+            const options = targetParts.slice(2).reduce((res, cur) => {
+                const parts = cur.split("=");
+                if (parts.length === 2) {
+                    const value = parseFloat(parts[1]);
+                    res[parts[0]] = isNaN(value) ? parts[1] : value;
+                }
+                return res;
+            }, {});
+            if (targetParts[1] === "iframedialog") {
+                this.props.showIframeDialog(targetParts[2], url, {title: title, icon: icon, ...options});
+            } else {
+                this.props.openExternalUrl(url);
+            }
+        } else if (target === "iframe") {
             this.props.showIframeDialog("externallinkiframe", url, {title: title, icon: icon});
         } else {
             this.props.openExternalUrl(url);

--- a/plugins/TopBar.jsx
+++ b/plugins/TopBar.jsx
@@ -160,9 +160,9 @@ class TopBar extends React.Component {
             </Swipeable>
         );
     }
-    openUrl = (url, target, title, options) => {
+    openUrl = (url, target, title, icon) => {
         if (target === "iframe") {
-            this.props.showIframeDialog("externallinkiframe", url, {title: title, ...options});
+            this.props.showIframeDialog("externallinkiframe", url, {title: title, icon: icon});
         } else {
             this.props.openExternalUrl(url);
         }

--- a/plugins/TopBar.jsx
+++ b/plugins/TopBar.jsx
@@ -160,9 +160,9 @@ class TopBar extends React.Component {
             </Swipeable>
         );
     }
-    openUrl = (url, target, title, icon) => {
+    openUrl = (url, target, title, options) => {
         if (target === "iframe") {
-            this.props.showIframeDialog("externallinkiframe", url, {title: title, icon: icon});
+            this.props.showIframeDialog("externallinkiframe", url, {title: title, ...options});
         } else {
             this.props.openExternalUrl(url);
         }


### PR DESCRIPTION
Add property `iframeOptions` for menuItems/toolbarItems and `termsUrlOptions`/`viewertitleUrlOptions`for BottomBar to define the ResizeableWindow options (dockable, printable, etc.)