### PR TITLE
Fix fallback filename in Print plugin

### DIFF
--- a/plugins/Print.jsx
+++ b/plugins/Print.jsx
@@ -601,7 +601,8 @@ class Print extends React.Component {
                 const fileURL = URL.createObjectURL(file);
                 this.setState({ pdfData: fileURL, outputLoaded: true });
             } else {
-                FileSaver.saveAs(file, this.props.theme.name + '.pdf');
+                const ext = this.state.selectedFormat.split(";")[0].split("/").pop();
+                FileSaver.saveAs(file, this.props.theme.name + '.' + ext);
             }
         }).catch(e => {
             this.setState({printing: false});


### PR DESCRIPTION
With `inlinePrintOutput` deactivated, the print plugin on chromium based web browsers always returns a `.pdf` file, no matter which print format is selected (jpeg, png, ...). Firefox doesn't have this problem.

There was the same problem with the MapExport plugin before (https://github.com/qgis/qwc2-demo-app/issues/489 / https://github.com/qgis/qwc2/commit/c8a7b3f9e60279b6eba24fc2217d86827d9d0b31). I added the solution from that issue to the print plugin as well.