### PR TITLE
Do not automatically submit search for single parameter if text is manually typed 

### DIFF
--- a/components/SearchBox.jsx
+++ b/components/SearchBox.jsx
@@ -88,7 +88,8 @@ class SearchBox extends React.Component {
         activeLayerInfo: null,
         filterOptionsVisible: false,
         selectedProvider: "",
-        selectedFilterRegion: null
+        selectedFilterRegion: null,
+        comesFromUrl: undefined
     };
     constructor(props) {
         super(props);
@@ -131,7 +132,7 @@ class SearchBox extends React.Component {
                     }
                 }).catch(() => {});
             } else if (st) {
-                this.setState({searchText: st}, this.startSearch);
+                this.setState({searchText: st, comesFromUrl: true}, this.startSearch);
             }
             UrlParams.updateParams({hp: undefined, hf: undefined, ht: undefined, st: undefined});
         } else if (this.props.theme !== prevProps.theme) {
@@ -167,7 +168,8 @@ class SearchBox extends React.Component {
                 const uniqueResult = uniqueResults[0];
                 if (uniqueResult[0] === "__fulltext" && uniqueResult[1].results[0].feature) {
                     this.selectFeatureResult(uniqueResult[1].results[0].feature);
-                } else if (uniqueResults[0] !== "__fulltext" && uniqueResult[1].results[0].items[0].bbox) {
+                } else if (uniqueResults[0] !== "__fulltext" && uniqueResult[1].results[0].items[0].bbox && this.state.comesFromUrl == true) {
+                    this.setState({comesFromUrl: undefined});
                     this.selectProviderResult(uniqueResult[1].results[0], uniqueResult[1].results[0].items[0], uniqueResult[0]);
                 }
             }


### PR DESCRIPTION
Hello @manisandro, 

Fist of all thanks for the quick fix about [this](https://github.com/qgis/qwc2-demo-app/issues/521).
But I would like to submit this PR to change it a bit if possible. 

For me, it seems a little "aggresive" to have the search automatically submited when user type text in the bar if there is only one result. 
People tend to make mistakes etc and you may want to verify your search result before letting the map moving you somewhere. 

But still it would be great to have the autosearch with the st= url parameters. 
So I've made a new state to determine if the search is triggered from st= or not. 

I don't know if my solution is optimal so let me know if it needs modification. 

Thanks in advance for your answer, 
Regards, Clément. 
