### PR TITLE
Bug fix: manage if data is null on identify onShow

### DIFF
--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -306,8 +306,8 @@ class Identify extends React.Component {
         });
     };
     onShow = (mode, data) => {
-        this.setState({mode: mode || 'Point', exitTaskOnResultsClose: data.exitTaskOnResultsClose});
-        if (mode === "Point" && data.pos) {
+        this.setState({mode: mode || 'Point', exitTaskOnResultsClose: data?.exitTaskOnResultsClose});
+        if (mode === "Point" && data?.pos) {
             this.identifyPoint(data.pos);
         }
         if (mode === "Region") {


### PR DESCRIPTION
Hi @manisandro. There was a bug on the previous pull request (#301) that chashed the app if data was null. This should fix it.

Sorry and thanks!