### PR TITLE
Add an icon in themeswitcher to choose user default theme

### DIFF
--- a/components/ThemeList.jsx
+++ b/components/ThemeList.jsx
@@ -30,6 +30,7 @@ class ThemeList extends React.Component {
         allowAddingOtherThemes: PropTypes.bool,
         changeTheme: PropTypes.func,
         collapsibleGroups: PropTypes.bool,
+        defaultUrlParams: PropTypes.string,
         dontPreserveSettingsOnSwitch: PropTypes.bool,
         filter: PropTypes.string,
         layers: PropTypes.array,
@@ -37,10 +38,9 @@ class ThemeList extends React.Component {
         setActiveLayerInfo: PropTypes.func,
         setCurrentTask: PropTypes.func,
         setThemeLayersList: PropTypes.func,
-        showLayerAfterChangeTheme: PropTypes.bool,
-        themes: PropTypes.object,
-        defaultUrlParams: PropTypes.string,
         showDefaultThemeSelector: PropTypes.bool,
+        showLayerAfterChangeTheme: PropTypes.bool,
+        themes: PropTypes.object
     };
     state = {
         expandedGroups: [],
@@ -88,8 +88,8 @@ class ThemeList extends React.Component {
         const activeThemeId = this.props.activeTheme ? this.props.activeTheme.id : null;
         const addLayersTitle = LocaleUtils.tr("themeswitcher.addlayerstotheme");
         const addTitle = LocaleUtils.tr("themeswitcher.addtotheme");
-        const openTabTitle = LocaleUtils.tr("themeswitcher.openintab");
         const changeDefaultUrlTitle = LocaleUtils.tr("themeswitcher.changedefaulttheme");
+        const openTabTitle = LocaleUtils.tr("themeswitcher.openintab");
         const username = ConfigUtils.getConfigProp("username");
 
         return (
@@ -207,12 +207,7 @@ class ThemeList extends React.Component {
         ];
     };
     extractThemeId = (text) => {
-        if (text) {
-            if (text.substr(0,2)=='t=') {
-                return text.substr(2)
-            }
-        }
-        return text
+        return Object.fromEntries(text.split("&").map(x => x.split("="))).t
     };
     setTheme = (theme) => {
         if (theme.restricted) {

--- a/components/ThemeList.jsx
+++ b/components/ThemeList.jsx
@@ -38,6 +38,7 @@ class ThemeList extends React.Component {
         setActiveLayerInfo: PropTypes.func,
         setCurrentTask: PropTypes.func,
         setThemeLayersList: PropTypes.func,
+        setUserInfoFields: PropTypes.func,
         showDefaultThemeSelector: PropTypes.bool,
         showLayerAfterChangeTheme: PropTypes.bool,
         themes: PropTypes.object
@@ -150,7 +151,7 @@ class ThemeList extends React.Component {
                                     {this.props.allowAddingOtherThemes ? (<Icon icon="layers" onClick={ev => this.getThemeLayersToList(ev, item)} title={addLayersTitle} />) : null}
                                     {this.props.allowAddingOtherThemes ? (<Icon icon="plus" onClick={ev => this.addThemeLayers(ev, item)} title={addTitle} />) : null}
                                     <Icon icon="open_link" onClick={ev => this.openInTab(ev, item.id)} title={openTabTitle} />
-                                    {this.props.showDefaultThemeSelector && username  ? (<Icon icon="new" onClick={ev => this.changeDefaultUrlParams(ev, item.id)} title={changeDefaultUrlTitle} className={ (this.extractThemeId(this.props.defaultUrlParams) == item.id ? "icon-active" : "")}/>) : null }
+                                    {this.props.showDefaultThemeSelector && username  ? (<Icon className={ (this.extractThemeId(this.props.defaultUrlParams) === item.id ? "icon-active" : "")} icon="new" onClick={ev => this.changeDefaultUrlParams(ev, item.id)} title={changeDefaultUrlTitle} />) : null }
                                 </div>
                             ) : (
                                 <div className="theme-item-restricted-overlay">
@@ -207,7 +208,7 @@ class ThemeList extends React.Component {
         ];
     };
     extractThemeId = (text) => {
-        return Object.fromEntries(text.split("&").map(x => x.split("="))).t
+        return Object.fromEntries(text.split("&").map(x => x.split("="))).t;
     };
     setTheme = (theme) => {
         if (theme.restricted) {
@@ -253,7 +254,7 @@ class ThemeList extends React.Component {
     changeDefaultUrlParams = (ev, themeid) => {
         ev.stopPropagation();
         const params = {
-            default_url_params: "t="+themeid
+            default_url_params: "t=" + themeid
         };
         const baseurl = location.href.split("?")[0].replace(/\/$/, '');
         axios.get(baseurl + "/setuserinfo", {params}).then(response => {
@@ -274,7 +275,7 @@ const selector = (state) => ({
     themes: state.theme.themes || {},
     layers: state.layers.flat,
     mapConfig: state.map,
-    defaultUrlParams: state.localConfig.user_infos?.default_url_params || "",
+    defaultUrlParams: state.localConfig.user_infos?.default_url_params || ""
 });
 
 export default connect(selector, {

--- a/components/style/ThemeList.css
+++ b/components/style/ThemeList.css
@@ -92,6 +92,10 @@ div.ThemeList li.theme-item:hover {
     border: 1px solid var(--color-active);
 }
 
+div.ThemeList div.theme-item-icons > span.icon-active {
+    color: var(--color-active);
+}
+
 div.ThemeList div.theme-item-keywords {
     position: relative;
     display: inline-block;

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -684,6 +684,7 @@ Theme switcher panel.
 | Property | Type | Description | Default value |
 |----------|------|-------------|---------------|
 | collapsibleGroups | `bool` | Whether to allow collapsing theme groups. | `undefined` |
+| showDefaultThemeSelector | `bool` | Whether to show an icon to select the default theme/bookmark (of a logged in user). | `true` |
 | showLayerAfterChangeTheme | `bool` | Whether to show the LayerTree by default after switching the theme. | `false` |
 | showThemeFilter | `bool` | Wether to show the theme filter field in the top bar. * | `true` |
 | side | `string` | The side of the application on which to display the sidebar. | `'right'` |

--- a/plugins/ThemeSwitcher.jsx
+++ b/plugins/ThemeSwitcher.jsx
@@ -47,8 +47,8 @@ class ThemeSwitcher extends React.Component {
     static defaultProps = {
         width: "50%",
         showThemeFilter: true,
-        showLayerAfterChangeTheme: false,
         showDefaultThemeSelector: true,
+        showLayerAfterChangeTheme: false,
         themeLayersListWindowSize: {width: 400, height: 300},
         side: 'right'
     };

--- a/plugins/ThemeSwitcher.jsx
+++ b/plugins/ThemeSwitcher.jsx
@@ -77,7 +77,7 @@ class ThemeSwitcher extends React.Component {
                                 activeTheme={this.props.activeTheme}
                                 allowAddingOtherThemes={allowAddingOtherThemes}
                                 collapsibleGroups={this.props.collapsibleGroups}
-                                filter={this.state.filter} 
+                                filter={this.state.filter}
                                 showDefaultThemeSelector={this.props.showDefaultThemeSelector}
                                 showLayerAfterChangeTheme={this.props.showLayerAfterChangeTheme}/>
                         )

--- a/plugins/ThemeSwitcher.jsx
+++ b/plugins/ThemeSwitcher.jsx
@@ -28,6 +28,8 @@ class ThemeSwitcher extends React.Component {
         /** Whether to allow collapsing theme groups. */
         collapsibleGroups: PropTypes.bool,
         currentTask: PropTypes.object,
+        /** Whether to show an icon to select the default theme/bookmark (of a logged in user). */
+        showDefaultThemeSelector: PropTypes.bool,
         /** Whether to show the LayerTree by default after switching the theme. */
         showLayerAfterChangeTheme: PropTypes.bool,
         /** Wether to show the theme filter field in the top bar. **/
@@ -46,6 +48,7 @@ class ThemeSwitcher extends React.Component {
         width: "50%",
         showThemeFilter: true,
         showLayerAfterChangeTheme: false,
+        showDefaultThemeSelector: true,
         themeLayersListWindowSize: {width: 400, height: 300},
         side: 'right'
     };
@@ -74,8 +77,9 @@ class ThemeSwitcher extends React.Component {
                                 activeTheme={this.props.activeTheme}
                                 allowAddingOtherThemes={allowAddingOtherThemes}
                                 collapsibleGroups={this.props.collapsibleGroups}
-                                filter={this.state.filter}
-                                showLayerAfterChangeTheme={this.props.showLayerAfterChangeTheme} />
+                                filter={this.state.filter} 
+                                showDefaultThemeSelector={this.props.showDefaultThemeSelector}
+                                showLayerAfterChangeTheme={this.props.showLayerAfterChangeTheme}/>
                         )
                     })}
                 </SideBar>

--- a/translations/ca-ES.json
+++ b/translations/ca-ES.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "Afegir capes al mapa actual",
       "addtotheme": "Afegir al actual tema",
+      "changedefaulttheme": "",
       "confirmswitch": "Confirmar canvi",
       "filter": "Filtrant...",
       "match": {

--- a/translations/cs-CZ.json
+++ b/translations/cs-CZ.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "Přidat vrstvy do aktuálního tématu",
       "addtotheme": "Přidat k aktuálnímu tématu",
+      "changedefaulttheme": "",
       "confirmswitch": "Vrstvy které nejsou součástí tématu budou při přepnutí tématu ztraceny. Pokračovat?",
       "filter": "Filtr...",
       "match": {

--- a/translations/de-CH.json
+++ b/translations/de-CH.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "Ebenen der Karte hinzufügen",
       "addtotheme": "Dem aktuellen Thema hinzufügen",
+      "changedefaulttheme": "",
       "confirmswitch": "Ebenen, die nicht Teil des Themas sind, werden entfernt. Fortsetzen?",
       "filter": "Filter",
       "match": {

--- a/translations/de-DE.json
+++ b/translations/de-DE.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "Ebenen der Karte hinzufügen",
       "addtotheme": "Dem aktuellen Thema hinzufügen",
+      "changedefaulttheme": "",
       "confirmswitch": "Ebenen, die nicht Teil des Themas sind, werden entfernt. Fortsetzen?",
       "filter": "Filter",
       "match": {

--- a/translations/en-US.json
+++ b/translations/en-US.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "Add layers to current map",
       "addtotheme": "Add to current theme",
+      "changedefaulttheme": "Select this theme as default theme",
       "confirmswitch": "Non-theme layers will be lost when switching theme. Proceed?",
       "filter": "Filter...",
       "match": {

--- a/translations/es-ES.json
+++ b/translations/es-ES.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "Agregar capas al mapa actual",
       "addtotheme": "Agregar al actual tema",
+      "changedefaulttheme": "",
       "confirmswitch": "Las capas sin tema se perderán al cambiar de tema. Continuar?",
       "filter": "Filtrar...",
       "match": {

--- a/translations/fi-FI.json
+++ b/translations/fi-FI.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "Lisää tasoja nykyiseen karttaan",
       "addtotheme": "Lisää nykyiseen teemaan",
+      "changedefaulttheme": "",
       "confirmswitch": "",
       "filter": "Suodatus...",
       "match": {

--- a/translations/fr-FR.json
+++ b/translations/fr-FR.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "Ajouter des couches à la carte",
       "addtotheme": "Ajouter au thème actuel",
+      "changedefaulttheme": "Sélectionner ce thème comme thème par défaut",
       "confirmswitch": "Les couches ajoutées par vos soins seront perdues en changeant de thème. Voulez-vous continuer ?",
       "filter": "Filtre...",
       "match": {

--- a/translations/hu-HU.json
+++ b/translations/hu-HU.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "",
       "addtotheme": "",
+      "changedefaulttheme": "",
       "confirmswitch": "",
       "filter": "Szűrés...",
       "match": {

--- a/translations/it-IT.json
+++ b/translations/it-IT.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "Aggiungi layer alla mappa corrente",
       "addtotheme": "Aggiungere al tema corrente",
+      "changedefaulttheme": "",
       "confirmswitch": "Layer che non fanno parte del tema saranno rimossi. Procedere?",
       "filter": "Filtra...",
       "match": {

--- a/translations/no-NO.json
+++ b/translations/no-NO.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "",
       "addtotheme": "Legg til nåværende tema",
+      "changedefaulttheme": "",
       "confirmswitch": "",
       "filter": "Filtrer...",
       "match": {

--- a/translations/pl-PL.json
+++ b/translations/pl-PL.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "",
       "addtotheme": "Dodaj do obecnego motywu",
+      "changedefaulttheme": "",
       "confirmswitch": "",
       "filter": "Filtruj...",
       "match": {

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "Adicionar camadas ao mapa atual",
       "addtotheme": "Adicione ao tema atual",
+      "changedefaulttheme": "",
       "confirmswitch": "",
       "filter": "Filtro...",
       "match": {

--- a/translations/pt-PT.json
+++ b/translations/pt-PT.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "Adicionar Camadas ao Mapa Atual",
       "addtotheme": "Adicionar ao Tema Atual",
+      "changedefaulttheme": "",
       "confirmswitch": "Confirmar Mudança",
       "filter": "Filtrar...",
       "match": {

--- a/translations/ro-RO.json
+++ b/translations/ro-RO.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "Adaugă straturi în hartă",
       "addtotheme": "Adaugă în hartă",
+      "changedefaulttheme": "",
       "confirmswitch": "Straturile tematice care nu fac parte din temă vor fi pierdute la schimbarea temei curente. Continuați?",
       "filter": "Filtrare",
       "match": {

--- a/translations/ru-RU.json
+++ b/translations/ru-RU.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "",
       "addtotheme": "",
+      "changedefaulttheme": "",
       "confirmswitch": "",
       "filter": "Фильтр...",
       "match": {

--- a/translations/sv-SE.json
+++ b/translations/sv-SE.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "",
       "addtotheme": "Lägg till aktuellt tema",
+      "changedefaulttheme": "",
       "confirmswitch": "",
       "filter": "Filtrera...",
       "match": {

--- a/translations/tr-TR.json
+++ b/translations/tr-TR.json
@@ -476,6 +476,7 @@
     "themeswitcher": {
       "addlayerstotheme": "Geçerli haritaya katmanları ekle",
       "addtotheme": "Geçerli temaya ekle",
+      "changedefaulttheme": "",
       "confirmswitch": "",
       "filter": "Filtre...",
       "match": {

--- a/translations/tsconfig.json
+++ b/translations/tsconfig.json
@@ -400,6 +400,7 @@
     "themelayerslist.addselectedlayers",
     "themeswitcher.addlayerstotheme",
     "themeswitcher.addtotheme",
+    "themeswitcher.changedefaulttheme",
     "themeswitcher.confirmswitch",
     "themeswitcher.filter",
     "themeswitcher.match.abstract",


### PR DESCRIPTION
Hello, 
In this PR I propose to add a star icon (new.svg icon) on themes in themeswitcher to visualize and change default theme (for user logged).

![Screenshot 2024-01-30 at 12-30-11 QGIS Web Client 2](https://github.com/qgis/qwc2/assets/15909387/d48634d7-a31f-4c6c-b07f-9f9b422b5108)

I add an option (like in settings plugin) in themeswitcher plugin config to get or not this icon. 

What do you think about that ? 

Have a good day