### PR TITLE
Select identifiable layers

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -365,6 +365,7 @@ with containing a container element with id=legendcontainer.
 | allowCompare | `bool` | Whether to enable the compare function. Requires the `MapCompare` plugin. | `true` |
 | allowImport | `bool` | Whether to allow importing external layers. | `true` |
 | allowMapTips | `bool` | Whether to allow enabling map tips. | `true` |
+| allowSelectIdentifyableLayers | `bool` | Whether to allow selection of identifyable layers. showQueryableIcon property should be `true` to be able to select identifyable layers | `false` |
 | bboxDependentLegend | `{bool, string}` | Whether to display a BBOX dependent legend. Can be `true|false|"theme"`, latter means only for theme layers. | `false` |
 | enableLegendPrint | `bool` | Whether to enable the legend print functionality. | `true` |
 | enableServiceInfo | `bool` | Whether to display a service info button to display the WMS service metadata. | `true` |

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -365,7 +365,7 @@ with containing a container element with id=legendcontainer.
 | allowCompare | `bool` | Whether to enable the compare function. Requires the `MapCompare` plugin. | `true` |
 | allowImport | `bool` | Whether to allow importing external layers. | `true` |
 | allowMapTips | `bool` | Whether to allow enabling map tips. | `true` |
-| allowSelectIdentifyableLayers | `bool` | Whether to allow selection of identifyable layers. showQueryableIcon property should be `true` to be able to select identifyable layers | `false` |
+| allowSelectIdentifyableLayers | `bool` | Whether to allow selection of identifyable layers. The `showQueryableIcon` property should be `true` to be able to select identifyable layers. | `false` |
 | bboxDependentLegend | `{bool, string}` | Whether to display a BBOX dependent legend. Can be `true|false|"theme"`, latter means only for theme layers. | `false` |
 | enableLegendPrint | `bool` | Whether to enable the legend print functionality. | `true` |
 | enableServiceInfo | `bool` | Whether to display a service info button to display the WMS service metadata. | `true` |

--- a/plugins/LayerTree.jsx
+++ b/plugins/LayerTree.jsx
@@ -49,7 +49,7 @@ class LayerTree extends React.Component {
         allowImport: PropTypes.bool,
         /** Whether to allow enabling map tips. */
         allowMapTips: PropTypes.bool,
-        /** Whether to allow selection of identifyable layers. */
+        /** Whether to allow selection of identifyable layers. The `showQueryableIcon` property should be `true` to be able to select identifyable layers. */
         allowSelectIdentifyableLayers: PropTypes.bool,
         /** Whether to display a BBOX dependent legend. Can be `true|false|"theme"`, latter means only for theme layers. */
         bboxDependentLegend: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),

--- a/plugins/LayerTree.jsx
+++ b/plugins/LayerTree.jsx
@@ -305,7 +305,7 @@ class LayerTree extends React.Component {
         }
         let queryableicon = null;
         if (this.props.allowSelectIdentifyableLayers) {
-            const identifyableClassName = !sublayer.omitFromQueryLayers ? ("layertree-item-identifyable-checked") : "layertree-item-identifyable-unchecked";
+            const identifyableClassName = !sublayer.omitFromQueryLayers ? "layertree-item-identifyable-checked" : "layertree-item-identifyable-unchecked";
             queryableicon = <Icon className={"layertree-item-identifyable " + identifyableClassName} icon="info-sign" onClick={() => this.itemOmitQueryableToggled(layer, path, sublayer.omitFromQueryLayers)}/>;
         } else {
             queryableicon = <Icon className="layertree-item-queryable" icon="info-sign"/>;

--- a/plugins/LayerTree.jsx
+++ b/plugins/LayerTree.jsx
@@ -49,7 +49,7 @@ class LayerTree extends React.Component {
         allowImport: PropTypes.bool,
         /** Whether to allow enabling map tips. */
         allowMapTips: PropTypes.bool,
-        /** Whether to allow selection of Identifyable Layers. */
+        /** Whether to allow selection of identifyable layers. */
         allowSelectIdentifyableLayers: PropTypes.bool,
         /** Whether to display a BBOX dependent legend. Can be `true|false|"theme"`, latter means only for theme layers. */
         bboxDependentLegend: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),

--- a/plugins/LayerTree.jsx
+++ b/plugins/LayerTree.jsx
@@ -49,6 +49,8 @@ class LayerTree extends React.Component {
         allowImport: PropTypes.bool,
         /** Whether to allow enabling map tips. */
         allowMapTips: PropTypes.bool,
+        /** Whether to allow selection of Identifyable Layers. */
+        allowSelectIdentifyableLayers: PropTypes.bool,
         /** Whether to display a BBOX dependent legend. Can be `true|false|"theme"`, latter means only for theme layers. */
         bboxDependentLegend: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
         changeLayerProperty: PropTypes.func,
@@ -118,6 +120,7 @@ class LayerTree extends React.Component {
         allowMapTips: true,
         allowCompare: true,
         allowImport: true,
+        allowSelectIdentifyableLayers: false,
         groupTogglesSublayers: false,
         grayUnchecked: true,
         layerInfoGeometry: {
@@ -299,7 +302,7 @@ class LayerTree extends React.Component {
                     {checkbox}
                     {legendicon}
                     {title}
-                    {sublayer.queryable && this.props.showQueryableIcon ? (<Icon className="layertree-item-queryable" icon="info-sign" />) : null}
+                    {sublayer.queryable && this.props.showQueryableIcon ? (<Icon className={this.props.allowSelectIdentifyableLayers ? ("layertree-item-identifyable icon_clickable layertree-item-identifyable-active") : "layertree-item-queryable"} icon="info-sign" />) : null}
                     {this.props.loadingLayers.includes(layer.id) ? (<Spinner />) : null}
                     <span className="layertree-item-spacer" />
                     {allowOptions && !this.props.infoInSettings ? infoButton : null}

--- a/plugins/LayerTree.jsx
+++ b/plugins/LayerTree.jsx
@@ -305,7 +305,7 @@ class LayerTree extends React.Component {
                     {checkbox}
                     {legendicon}
                     {title}
-                    {queryable && this.props.showQueryableIcon ? (<Icon className={this.props.allowSelectIdentifyableLayers ? ("layertree-item-identifyable icon_clickable " + identifyableClassName ) : "layertree-item-queryable"} icon="info-sign" onClick={() => this.modifyLayerIdentifyable(sublayer.name, layer)} />) : null}
+                    {queryable && this.props.showQueryableIcon ? (<Icon className={this.props.allowSelectIdentifyableLayers ? ("layertree-item-identifyable icon_clickable " + identifyableClassName ) : "layertree-item-queryable"} icon="info-sign" onClick={() => this.subLayerIdentifyableToggled(sublayer.name, layer)} />) : null}
                     {this.props.loadingLayers.includes(layer.id) ? (<Spinner />) : null}
                     <span className="layertree-item-spacer" />
                     {allowOptions && !this.props.infoInSettings ? infoButton : null}
@@ -719,7 +719,7 @@ class LayerTree extends React.Component {
         FileSaver.saveAs(new Blob([data], {type: "text/plain;charset=utf-8"}), layer.title + ".json");
     };
 
-    modifyLayerIdentifyable = (sublayername, layer) => {
+    subLayerIdentifyableToggled = (sublayername, layer) => {
         let newQueryLayers = [];
         if (layer.queryLayers.includes(sublayername)) { // sublayer was identifyable, we should remove it
             newQueryLayers = layer.queryLayers.filter((item) => item !== sublayername);

--- a/plugins/LayerTree.jsx
+++ b/plugins/LayerTree.jsx
@@ -294,6 +294,9 @@ class LayerTree extends React.Component {
         const allowSeparators = flattenGroups && allowReordering && ConfigUtils.getConfigProp("allowLayerTreeSeparators", this.props.theme);
         const separatorTitle = LocaleUtils.tr("layertree.separator");
         const separatorTooltip = LocaleUtils.tr("layertree.separatortooltip");
+        const queryable = layer.initialQueryLayers ? (layer.initialQueryLayers.includes(sublayer.name)) : false;
+        const identifyable = layer.queryLayers ? (layer.queryLayers.includes(sublayer.name)) : false;
+        const identifyableClassName = identifyable ? ("layertree-item-identifyable-active") : "";
         return (
             <div className="layertree-item-container" data-id={JSON.stringify({layer: layer.uuid, path: path})} key={sublayer.uuid}>
                 {allowSeparators ? (<div className="layertree-item-addsep" onClick={() => this.props.addLayerSeparator(separatorTitle, layer.id, path)} title={separatorTooltip} />) : null}
@@ -302,7 +305,7 @@ class LayerTree extends React.Component {
                     {checkbox}
                     {legendicon}
                     {title}
-                    {sublayer.queryable && this.props.showQueryableIcon ? (<Icon className={this.props.allowSelectIdentifyableLayers ? ("layertree-item-identifyable icon_clickable layertree-item-identifyable-active") : "layertree-item-queryable"} icon="info-sign" />) : null}
+                    {queryable && this.props.showQueryableIcon ? (<Icon className={this.props.allowSelectIdentifyableLayers ? ("layertree-item-identifyable icon_clickable " + identifyableClassName ) : "layertree-item-queryable"} icon="info-sign" onClick={() => this.modifyLayerIdentifyable(sublayer.name, layer)} />) : null}
                     {this.props.loadingLayers.includes(layer.id) ? (<Spinner />) : null}
                     <span className="layertree-item-spacer" />
                     {allowOptions && !this.props.infoInSettings ? infoButton : null}
@@ -714,6 +717,16 @@ class LayerTree extends React.Component {
             features: layer.features.map(feature => ({...feature, geometry: VectorLayerUtils.reprojectGeometry(feature.geometry, feature.crs || this.props.map.projection, 'EPSG:4326')}))
         }, null, ' ');
         FileSaver.saveAs(new Blob([data], {type: "text/plain;charset=utf-8"}), layer.title + ".json");
+    };
+
+    modifyLayerIdentifyable = (sublayername, layer) => {
+        let newQueryLayers = [];
+        if (layer.queryLayers.includes(sublayername)) { // sublayer was identifyable, we should remove it
+            newQueryLayers = layer.queryLayers.filter((item) => item !== sublayername);
+        } else { // sublayer was not identifyable, we should add it
+            newQueryLayers = layer.queryLayers.concat(sublayername);
+        }
+        this.props.changeLayerProperty(layer.uuid, "queryLayers", newQueryLayers, [], "parents");
     };
 }
 

--- a/plugins/style/LayerTree.css
+++ b/plugins/style/LayerTree.css
@@ -197,7 +197,7 @@ img.layertree-item-legend-tooltip {
 }
 
 #LayerTree span.layertree-item-identifyable-tristate {
-    color: var(--color---text-color);
+    color: var(--text-color);
 }
 
 #LayerTree span.layertree-item-spacer {

--- a/plugins/style/LayerTree.css
+++ b/plugins/style/LayerTree.css
@@ -181,6 +181,18 @@ img.layertree-item-legend-tooltip {
     flex: 0 0 auto;
 }
 
+#LayerTree span.layertree-item-identifyable {
+    margin-left: 0.25em;
+    color: var(--border-color);
+    font-size: small;
+    vertical-align: top;
+    flex: 0 0 auto;
+}
+
+#LayerTree span.layertree-item-identifyable-active {
+    color: var(--color-active);
+}
+
 #LayerTree span.layertree-item-spacer {
     flex: 1 1 auto;
 }

--- a/plugins/style/LayerTree.css
+++ b/plugins/style/LayerTree.css
@@ -183,14 +183,21 @@ img.layertree-item-legend-tooltip {
 
 #LayerTree span.layertree-item-identifyable {
     margin-left: 0.25em;
-    color: var(--border-color);
     font-size: small;
     vertical-align: top;
     flex: 0 0 auto;
 }
 
-#LayerTree span.layertree-item-identifyable-active {
+#LayerTree span.layertree-item-identifyable-unchecked {
+    color: var(--border-color);
+}
+
+#LayerTree span.layertree-item-identifyable-checked {
     color: var(--color-active);
+}
+
+#LayerTree span.layertree-item-identifyable-tristate {
+    color: var(--color---text-color);
 }
 
 #LayerTree span.layertree-item-spacer {

--- a/utils/LayerUtils.js
+++ b/utils/LayerUtils.js
@@ -172,7 +172,7 @@ const LayerUtils = {
                 STYLES: layer.style ?? params.STYLES ?? "",
                 ...layer.dimensionValues
             };
-            queryLayers = layer.queryable && !layer.omitFromQuerylayers ? [layer.name] : [];
+            queryLayers = layer.queryable && !layer.omitFromQueryLayers ? [layer.name] : [];
         } else {
             let layerNames = [];
             let opacities = [];
@@ -601,6 +601,18 @@ const LayerUtils = {
             opacity += LayerUtils.computeLayerOpacity(sublayer);
         });
         return opacity / layer.sublayers.length;
+    },
+    computeLayerQueryable(layer) {
+        let queryable = 0;
+        layer.sublayers.map(sublayer => {
+            const sublayerqueryable = !sublayer.omitFromQueryLayers ?? true;
+            if (sublayer.sublayers && sublayerqueryable) {
+                queryable += LayerUtils.computeLayerQueryable(sublayer);
+            } else {
+                queryable += sublayerqueryable ? 1 : 0;
+            }
+        });
+        return queryable / layer.sublayers.length;
     },
     cloneLayer(layer, sublayerpath) {
         const newlayer = {...layer};

--- a/utils/LayerUtils.js
+++ b/utils/LayerUtils.js
@@ -142,7 +142,7 @@ const LayerUtils = {
                 opacities.push(Number.isInteger(sublayer.opacity) ? sublayer.opacity : 255);
                 // Only specify style if more than one style choice exists
                 styles.push(Object.keys(sublayer.styles || {}).length > 1 ? (sublayer.style || "") : "");
-                if (sublayer.queryable) {
+                if (sublayer.queryable && !sublayer.omitFromQueryLayers) {
                     queryable.push(sublayer.name);
                 }
                 if (visibilities) {
@@ -154,9 +154,8 @@ const LayerUtils = {
     buildWMSLayerParams(layer) {
         const params = layer.params || {};
         let newParams = {};
-        let initialQueryLayers = [];
+        let queryLayers = [];
         let initialOpacities = undefined;
-        let queryLayers = layer.queryLayers;
 
         if (!Array.isArray(layer.sublayers)) {
             // Background layers may just contain layer.params.OPACITIES
@@ -173,13 +172,13 @@ const LayerUtils = {
                 STYLES: layer.style ?? params.STYLES ?? "",
                 ...layer.dimensionValues
             };
-            initialQueryLayers = layer.queryable ? [layer.name] : [];
+            queryLayers = layer.queryable && !layer.omitFromQuerylayers ? [layer.name] : [];
         } else {
             let layerNames = [];
             let opacities = [];
             let styles = [];
             layer.sublayers.map(sublayer => {
-                LayerUtils.collectWMSSublayerParams(sublayer, layerNames, opacities, styles, initialQueryLayers, null, layer.visibility);
+                LayerUtils.collectWMSSublayerParams(sublayer, layerNames, opacities, styles, queryLayers, null, layer.visibility);
             });
             layerNames.reverse();
             opacities.reverse();
@@ -198,49 +197,11 @@ const LayerUtils = {
             };
         }
 
-        if (queryLayers) { // not first add
-            const newParamsLayers = newParams.LAYERS.split(',').sort((a, b) => a.localeCompare(b)) || [];
-            const paramsLayers = params.LAYERS.split(',').sort((a, b) => a.localeCompare(b)) || [];
-            if (JSON.stringify(newParamsLayers) !== JSON.stringify(paramsLayers)) {
-                // If newparams.layers != params.layers there are layers added or not visualised any more
-                if (newParamsLayers.length >= paramsLayers.length) {
-                    // A layer is added. Add this new layer to queryLayers
-                    queryLayers = queryLayers.concat(LayerUtils.findFirstDifferenceList(paramsLayers, newParamsLayers));
-                } else {
-                    // A layer is hidden. Remove it from queryLayers
-                    const toRemove = LayerUtils.findFirstDifferenceList(newParamsLayers, paramsLayers);
-                    queryLayers = queryLayers.filter(value => value !== toRemove);
-                }
-            } else {
-                // If newparams.layers == params.layers
-                // but there is more layers in layer.queryLayers, a layer was deleted.
-                if (queryLayers.length > paramsLayers.length) {
-                    // Remove this layer from layer.queryLayers
-                    const toRemove = LayerUtils.findFirstDifferenceList(paramsLayers, queryLayers);
-                    queryLayers = queryLayers.filter(value => value === toRemove);
-                }
-            }
-        }
         return {
             params: newParams,
-            initialQueryLayers: initialQueryLayers, // store initialQueryLayers List
-            queryLayers: queryLayers || initialQueryLayers,
+            queryLayers: queryLayers,
             initialOpacities: initialOpacities
         };
-    },
-    findFirstDifferenceList(smallList, longList_) {
-        for (let i = 0; i < smallList.length; i++) {
-            if (smallList[i] !== longList_[i]) {
-                return longList_[i];
-            }
-        }
-        // If all common elements are the same, check if one list is longer
-        if (smallList.length !== longList_.length) {
-            const index = smallList.length;
-            return longList_[index];
-        }
-        // If the lists are identical
-        return null;
     },
     addUUIDs(group, usedUUIDs = new Set()) {
         group.uuid = !group.uuid || usedUUIDs.has(group.uuid) ? uuidv4() : group.uuid;

--- a/utils/LayerUtils.js
+++ b/utils/LayerUtils.js
@@ -198,20 +198,6 @@ const LayerUtils = {
             };
         }
 
-        function findFirstDifferenceList(smallList, longList_) {
-            for (let i = 0; i < smallList.length; i++) {
-                if (smallList[i] !== longList_[i]) {
-                    return longList_[i];
-                }
-            }
-            // If all common elements are the same, check if one list is longer
-            if (smallList.length !== longList_.length) {
-                const index = smallList.length;
-                return longList_[index];
-            }
-            // If the lists are identical
-            return null;
-        }
         if (queryLayers) { // not first add
             const newParamsLayers = newParams.LAYERS.split(',').sort((a, b) => a.localeCompare(b)) || [];
             const paramsLayers = params.LAYERS.split(',').sort((a, b) => a.localeCompare(b)) || [];
@@ -219,10 +205,10 @@ const LayerUtils = {
                 // If newparams.layers != params.layers there are layers added or not visualised any more
                 if (newParamsLayers.length >= paramsLayers.length) {
                     // A layer is added. Add this new layer to queryLayers
-                    queryLayers = queryLayers.concat(findFirstDifferenceList(paramsLayers, newParamsLayers));
+                    queryLayers = queryLayers.concat(LayerUtils.findFirstDifferenceList(paramsLayers, newParamsLayers));
                 } else {
                     // A layer is hidden. Remove it from queryLayers
-                    const toRemove = findFirstDifferenceList(newParamsLayers, paramsLayers);
+                    const toRemove = LayerUtils.findFirstDifferenceList(newParamsLayers, paramsLayers);
                     queryLayers = queryLayers.filter(value => value !== toRemove);
                 }
             } else {
@@ -230,7 +216,7 @@ const LayerUtils = {
                 // but there is more layers in layer.queryLayers, a layer was deleted.
                 if (queryLayers.length > paramsLayers.length) {
                     // Remove this layer from layer.queryLayers
-                    const toRemove = findFirstDifferenceList(paramsLayers, queryLayers);
+                    const toRemove = LayerUtils.findFirstDifferenceList(paramsLayers, queryLayers);
                     queryLayers = queryLayers.filter(value => value === toRemove);
                 }
             }
@@ -241,6 +227,20 @@ const LayerUtils = {
             queryLayers: queryLayers || initialQueryLayers,
             initialOpacities: initialOpacities
         };
+    },
+    findFirstDifferenceList(smallList, longList_) {
+        for (let i = 0; i < smallList.length; i++) {
+            if (smallList[i] !== longList_[i]) {
+                return longList_[i];
+            }
+        }
+        // If all common elements are the same, check if one list is longer
+        if (smallList.length !== longList_.length) {
+            const index = smallList.length;
+            return longList_[index];
+        }
+        // If the lists are identical
+        return null;
     },
     addUUIDs(group, usedUUIDs = new Set()) {
         group.uuid = !group.uuid || usedUUIDs.has(group.uuid) ? uuidv4() : group.uuid;


### PR DESCRIPTION
Hello, 

In this PR, I make the layer queryable icon clickable. User can choose which layers are queryable for Identify tool for example. 
I add an option in config.json to activate or not this feature.

![image](https://github.com/qgis/qwc2/assets/15909387/d95cb03d-bfe6-45e2-8063-085768e54b66)

Have a good day

_This feature has been funded by Grand Lyon Métropole https://www.grandlyon.com/_