### PR TITLE
Add prop to manage highlight on all identify results

### DIFF
--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -170,7 +170,8 @@ class IdentifyViewer extends React.Component {
         openExternalUrl: PropTypes.func,
         showLayerTitles: PropTypes.bool,
         theme: PropTypes.object,
-        zoomToExtent: PropTypes.func
+        zoomToExtent: PropTypes.func,
+        highlightAllResults: PropTypes.bool
     };
     static defaultProps = {
         longAttributesDisplay: 'ellipsis',
@@ -178,7 +179,8 @@ class IdentifyViewer extends React.Component {
         displayResultTree: true,
         attributeCalculator: (/* layer, feature */) => { return []; },
         attributeTransform: (name, value /* , layer, feature */) => value,
-        showLayerTitles: true
+        showLayerTitles: true,
+        highlightAllResults: true
     };
     state = {
         expanded: {},
@@ -231,12 +233,12 @@ class IdentifyViewer extends React.Component {
         });
     };
     setHighlightedResults = (results, resultTree) => {
-        if (!results) {
+        if (!results && this.props.highlightAllResults) {
             results = Object.keys(resultTree).reduce((res, layer) => {
                 return res.concat(resultTree[layer].map(result => ({...result, id: layer + "." + result.id})));
             }, []);
         }
-        results = results.filter(result => result.type.toLowerCase() === "feature");
+        results = (results || []).filter(result => result.type.toLowerCase() === "feature");
         if (!isEmpty(results)) {
             const layer = {
                 id: "identifyslection",

--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -85,7 +85,9 @@ class Identify extends React.Component {
         /** Whether to replace an attribute value containing an URL to an image with an inline image. */
         replaceImageUrls: PropTypes.bool,
         selection: PropTypes.object,
-        setCurrentTask: PropTypes.func
+        setCurrentTask: PropTypes.func,
+        /** Whether to highlight all results if no result is hovered */
+        highlightAllResults: PropTypes.bool
     };
     static defaultProps = {
         enableExport: true,
@@ -105,7 +107,8 @@ class Identify extends React.Component {
             side: 'left'
         },
         initialRadius: 50,
-        initialRadiusUnits: 'meters'
+        initialRadiusUnits: 'meters',
+        highlightAllResults: true
     };
     state = {
         mode: 'Point',
@@ -405,6 +408,7 @@ class Identify extends React.Component {
                         iframeDialogsInitiallyDocked={this.props.iframeDialogsInitiallyDocked}
                         longAttributesDisplay={this.props.longAttributesDisplay}
                         replaceImageUrls={this.props.replaceImageUrls}
+                        highlightAllResults={this.props.highlightAllResults}
                         role="body" />
                 );
             }


### PR DESCRIPTION
Hi!

I found that the Identify highlight on all features was a bit too intense, so I added this prop `highlightAllResults` that if it's set to `false` it will only highlight the selected feature/layer. 
By default it's `true`, so it should work exactly like it did before.

Let me know if I did something wrong.
Thanks!