### PR TITLE
fix missing groups in ThemeList when using subgroups

### DIFF
--- a/components/ThemeList.jsx
+++ b/components/ThemeList.jsx
@@ -74,7 +74,7 @@ class ThemeList extends React.Component {
         }
         const subtree = subdirs.map((subdir) => {
             const expanded = !this.props.collapsibleGroups || filter || this.state.expandedGroups.includes(subdir.id) || (this.props.activeTheme && this.groupContainsActiveTheme(subdir));
-            if (isEmpty(subdir.items)) {
+            if (isEmpty(subdir.items && isEmpty(subdir.subdirs))) {
                 return null;
             }
             return (


### PR DESCRIPTION
This solves the problem, that groups are not added to the theme list for users who doesn't have access to a item in the top level of the group. So if the user wants to access a theme that's located in group -> subgroup -> item/theme. In the present version, the whole group is not visible in theme list, when in the 'group' are no items/themes. 