### PR TITLE
Enable zoom by box selection

### DIFF
--- a/components/MapSelection.jsx
+++ b/components/MapSelection.jsx
@@ -21,7 +21,6 @@ class MapSelection extends React.Component {
     static propTypes = {
         /* Whether the selection tool is active */
         active: PropTypes.bool,
-        currentTask: PropTypes.string,
         /* Optional, a css-cursor to use when drawing */
         cursor: PropTypes.string,
         /* The selection geometry type (Point, LineString, Polygon, Circle, DragBox, Box) */
@@ -209,7 +208,6 @@ class MapSelection extends React.Component {
 }
 
 export default connect((state) => ({
-    currentTask: state.task.id,
     projection: state.map.projection
 }), {
 })(MapSelection);

--- a/components/MapSelection.jsx
+++ b/components/MapSelection.jsx
@@ -21,6 +21,7 @@ class MapSelection extends React.Component {
     static propTypes = {
         /* Whether the selection tool is active */
         active: PropTypes.bool,
+        currentTask: PropTypes.string,
         /* Optional, a css-cursor to use when drawing */
         cursor: PropTypes.string,
         /* The selection geometry type (Point, LineString, Polygon, Circle, DragBox, Box) */
@@ -103,6 +104,7 @@ class MapSelection extends React.Component {
     }
     componentWillUnmount() {
         this.map.removeLayer(this.selectionLayer);
+        this.removeDrawInteraction();
     }
     addDrawInteraction = () => {
         // cleanup old interaction
@@ -112,7 +114,9 @@ class MapSelection extends React.Component {
         if (this.props.geomType === "DragBox") {
             this.drawInteraction = new ol.interaction.DragBox({
                 className: 'selection-drag-box',
-                condition: ol.events.condition.shiftKeyOnly
+                condition: () => {
+                    return ["ZoomIn", "ZoomOut"].includes(this.props.currentTask) || ol.events.condition.shiftKeyOnly;
+                }
             });
 
             this.drawInteraction.on('boxend', () => {
@@ -208,6 +212,7 @@ class MapSelection extends React.Component {
 }
 
 export default connect((state) => ({
+    currentTask: state.task.id,
     projection: state.map.projection
 }), {
 })(MapSelection);

--- a/components/MapSelection.jsx
+++ b/components/MapSelection.jsx
@@ -113,10 +113,7 @@ class MapSelection extends React.Component {
         }
         if (this.props.geomType === "DragBox") {
             this.drawInteraction = new ol.interaction.DragBox({
-                className: 'selection-drag-box',
-                condition: () => {
-                    return ["ZoomIn", "ZoomOut"].includes(this.props.currentTask) || ol.events.condition.shiftKeyOnly;
-                }
+                className: 'selection-drag-box'
             });
 
             this.drawInteraction.on('boxend', () => {

--- a/plugins/ZoomButtons.jsx
+++ b/plugins/ZoomButtons.jsx
@@ -9,10 +9,13 @@
 import React from 'react';
 import {connect} from 'react-redux';
 
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
-import {changeZoomLevel} from '../actions/map';
+import {changeZoomLevel, zoomToExtent, zoomToPoint} from '../actions/map';
+import {setCurrentTask} from '../actions/task';
 import Icon from '../components/Icon';
+import MapSelection from '../components/MapSelection';
 import LocaleUtils from '../utils/LocaleUtils';
 import ThemeUtils from '../utils/ThemeUtils';
 
@@ -26,17 +29,58 @@ import './style/Buttons.css';
 class ZoomButton extends React.Component {
     static propTypes = {
         changeZoomLevel: PropTypes.func,
+        click: PropTypes.object,
+        currentTask: PropTypes.string,
         currentZoom: PropTypes.number,
         direction: PropTypes.number,
+        /** Enable zoom in or out by box selection. */
+        enableZoomByBoxSelection: PropTypes.bool,
+        mapCrs: PropTypes.string,
         mapMargins: PropTypes.object,
         maxZoom: PropTypes.number,
         /** The position slot index of the map button, from the bottom (0: bottom slot). */
         position: PropTypes.number,
+        setCurrentTask: PropTypes.func,
         theme: PropTypes.object,
         /** Omit the button in themes matching one of these flags. */
         themeFlagBlacklist: PropTypes.arrayOf(PropTypes.string),
         /** Only show the button in themes matching one of these flags. */
-        themeFlagWhitelist: PropTypes.arrayOf(PropTypes.string)
+        themeFlagWhitelist: PropTypes.arrayOf(PropTypes.string),
+        zoomToExtent: PropTypes.func,
+        zoomToPoint: PropTypes.func
+    };
+    static defaultProps = {
+        enableZoomByBoxSelection: false
+    };
+    state = {
+        disabled: false,
+        task: null,
+        zoomBox: null
+    };
+    componentDidUpdate(prevProps) {
+        if (prevProps !== this.props) {
+            if (this.props.direction > 0) {
+                this.setState({disabled: this.props.currentZoom >= this.props.maxZoom, task: "ZoomIn"});
+            } else if (this.props.direction < 0) {
+                this.setState({disabled: this.props.currentZoom <= 0, task: "ZoomOut"});
+            }
+        }
+        if (this.props.currentTask !== null && this.props.currentTask === this.state.task && this.state.disabled) {
+            this.props.setCurrentTask(null);
+        }
+        if (this.props.currentTask === this.state.task && prevProps !== this.props) {
+            const point = this.clickPoint(prevProps);
+            if (point) {
+                const zoom = Math.max(0, this.props.currentZoom + this.props.direction);
+                this.props.zoomToPoint(point, zoom, this.mapCrs);
+            }
+        }
+    }
+    clickPoint = (prevProps) => {
+        if (this.props.click === prevProps.click) {
+            return null;
+        }
+        return this.props.click.coordinate;
     };
     render() {
         if (!ThemeUtils.themFlagsAllowed(this.props.theme, this.props.themeFlagWhitelist, this.props.themeFlagBlacklist)) {
@@ -50,42 +94,83 @@ class ZoomButton extends React.Component {
             right: 'calc(1.5em + ' + right + 'px)',
             bottom: 'calc(' + bottom + 'px  + ' + (5 + 4 * position) + 'em)'
         };
-        let disabled = false;
-        if (this.props.direction > 0) {
-            disabled = this.props.currentZoom >= this.props.maxZoom;
-        } else if (this.props.direction < 0) {
-            disabled = this.props.currentZoom <= 0;
-        }
         const tooltip = this.props.direction > 0 ? LocaleUtils.tr("tooltip.zoomin") : LocaleUtils.tr("tooltip.zoomout");
-        return (
-            <button className="map-button"
-                disabled={disabled}
-                onClick={() => this.props.changeZoomLevel(this.props.currentZoom + this.props.direction)}
+        const classes = classnames({
+            "map-button": true,
+            "map-button-active": this.props.enableZoomByBoxSelection && this.props.currentTask === this.state.task,
+            "map-button-disabled": this.state.disabled
+        });
+        return [(
+            <button className={classes}
+                disabled={this.state.disabled}
+                key={this.state.task + "Button"}
+                onClick={this.buttonClicked}
                 style={style}
                 title={tooltip}
             >
                 <Icon icon={this.props.direction > 0 ? "plus" : "minus"} title={tooltip}/>
             </button>
-        );
+        ), (
+            this.props.currentTask === this.state.task ? (
+                <MapSelection
+                    active cursor={this.props.direction > 0 ? "zoom-in" : "zoom-out"}
+                    geomType="DragBox"
+                    geometryChanged={(geom) => this.updateZoom(geom)}
+                    key="MapSelection"
+                />
+            ) : null
+        )];
     }
+    buttonClicked = () => {
+        if (this.props.enableZoomByBoxSelection) {
+            const task = this.props.direction > 0 ? "ZoomIn" : "ZoomOut";
+            this.props.setCurrentTask(this.props.currentTask === task ? null : task);
+        } else {
+            this.props.changeZoomLevel(this.props.currentZoom + this.props.direction);
+        }
+    };
+    updateZoom = (geom) => {
+        this.setState(() => ({zoomBox: geom.coordinates[0]}), () => {
+            if (this.props.direction > 0) {
+                this.props.zoomToExtent(this.state.zoomBox, this.props.mapCrs);
+            } else {
+                const bounds = this.state.zoomBox;
+                const center = [0.5 * (bounds[0] + bounds[2]), 0.5 * (bounds[1] + bounds[3])];
+                const zoom = Math.max(0, this.props.currentZoom + this.props.direction);
+                this.props.zoomToPoint(center, zoom, this.props.mapCrs);
+            }
+        });
+    };
 }
 
 export const ZoomInPlugin = connect((state) => ({
+    click: state.map.click,
+    currentTask: state.task.id,
     currentZoom: state.map.zoom,
     maxZoom: state.map.resolutions.length - 1,
     direction: +1,
+    mapCrs: state.map.projection,
     mapMargins: state.windows.mapMargins,
     theme: state.theme.current
 }), {
-    changeZoomLevel: changeZoomLevel
+    changeZoomLevel: changeZoomLevel,
+    setCurrentTask: setCurrentTask,
+    zoomToExtent: zoomToExtent,
+    zoomToPoint: zoomToPoint
 })(ZoomButton);
 
 export const ZoomOutPlugin = connect((state) => ({
+    click: state.map.click || {},
+    currentTask: state.task.id,
     currentZoom: state.map.zoom,
     maxZoom: state.map.resolutions.length - 1,
     direction: -1,
+    mapCrs: state.map.projection,
     mapMargins: state.windows.mapMargins,
     theme: state.theme.current
 }), {
-    changeZoomLevel: changeZoomLevel
+    changeZoomLevel: changeZoomLevel,
+    setCurrentTask: setCurrentTask,
+    zoomToExtent: zoomToExtent,
+    zoomToPoint: zoomToPoint
 })(ZoomButton);

--- a/plugins/ZoomButtons.jsx
+++ b/plugins/ZoomButtons.jsx
@@ -68,20 +68,14 @@ class ZoomButton extends React.Component {
         if (this.props.currentTask !== null && this.props.currentTask === this.state.task && this.state.disabled) {
             this.props.setCurrentTask(null);
         }
-        if (this.props.currentTask === this.state.task && prevProps !== this.props) {
-            const point = this.clickPoint(prevProps);
+        if (this.props.currentTask === this.state.task && this.props.click !== prevProps.click) {
+            const point = this.props.click.coordinate;
             if (point) {
                 const zoom = Math.max(0, this.props.currentZoom + this.props.direction);
                 this.props.zoomToPoint(point, zoom, this.mapCrs);
             }
         }
     }
-    clickPoint = (prevProps) => {
-        if (this.props.click === prevProps.click) {
-            return null;
-        }
-        return this.props.click.coordinate;
-    };
     render() {
         if (!ThemeUtils.themFlagsAllowed(this.props.theme, this.props.themeFlagWhitelist, this.props.themeFlagBlacklist)) {
             return null;

--- a/plugins/style/Buttons.css
+++ b/plugins/style/Buttons.css
@@ -26,6 +26,16 @@ button.map-button-active {
     color: var(--map-button-active-text-color);
 }
 
+button.map-button-disabled {
+    opacity: 0.7;
+    cursor: default;
+}
+
+button.map-button-disabled:hover {
+    background-color: var(--map-button-bg-color);
+    color: var(--map-button-text-color);
+}
+
 button.map-button.locate-button-PERMISSION_DENIED {
     opacity: 0.7;
     cursor: default;


### PR DESCRIPTION
Hi,

This PR introduces a new `enableZoomByBoxSelection` option for `Zoom(In|Out)Plugin` to allow user to zoom by box selection. I needed to update `MapSelection` to make it work, I don't think I breaks something for other plugins that use this component but I'm not sure...

I tried to reproduce behavior for Zoom buttons in QGIS Desktop.

Here is a screencast with `enableZoomByBoxSelection: false` for `ZoomInPlugin` (actual behavior) and `enableZoomByBoxSelection: true` for `ZoomOutPlugin`:

![QWCZoomByBox](https://github.com/qgis/qwc2/assets/8960009/1c0508bd-4aa8-40f3-8e0b-b95873432e9f)

Thanks for the review !

_This feature has been funded by Grand Lyon Métropole https://www.grandlyon.com/_