### PR TITLE
use getMap url not capabilities url

### DIFF
--- a/utils/ServiceLayerUtils.js
+++ b/utils/ServiceLayerUtils.js
@@ -455,7 +455,7 @@ const ServiceLayerUtils = {
         }
         try {
             const urlParts = url.parse(capabilityUrl, true);
-            urlParts.host = calledServiceUrlParts.host;
+            urlParts.host = urlParts.host ?? calledServiceUrlParts.host;
             urlParts.protocol = calledServiceUrlParts.protocol ?? location.protocol;
             urlParts.query = {...calledServiceUrlParts.query, ...urlParts.query};
             delete urlParts.search;


### PR DESCRIPTION
if the getMapUrl or getLegendUrl doesn't match the getCapabilitiesUrl the mergeCalledSercideUrlQuery overwrites the before extracted url for the getMapUrl:
https://github.com/qgis/qwc2/blob/a4efb2bd5a7c78ff3f6bc47494c24457a927d37f/utils/ServiceLayerUtils.js#L134 

As example geodienste.ch is not working in LayerCatalog
GetCap: https://wms.geodienste.ch/db/kataster_belasteter_standorte_v1_4_0/deu?SERVICE=WMS&REQUEST=GetCapabilities
GetMapURL: https://wfs.geodienste.ch/kataster_belasteter_standorte_v1_4_0/deu?version=1.3.0&service=WMS&request=Get....
qwc2 will use wms.geodienste.ch/... as url for the getMap and getLegend request