### PR TITLE
Do not change protocol of urls in catalog.json

### DIFF
--- a/utils/ServiceLayerUtils.js
+++ b/utils/ServiceLayerUtils.js
@@ -355,7 +355,9 @@ const ServiceLayerUtils = {
             };
             delete urlParts.search;
         }
-        urlParts.protocol = location.protocol;
+        if (urlParts.protocol === "http" && location.protocol === "https") {
+            urlParts.protocol = "https";
+        }
         const requestUrl = url.format(urlParts);
         return new Promise((resolve, reject) => {
             axios.get(requestUrl).then(response => {


### PR DESCRIPTION
While investigating a CORS error that occurred when adding a layer using the LayerCatalog we discovered that the protocol part of urls in catalog.json are effectively ignored. 

When QWC is running at http://localhost:8081 (i.e. a typical development setup) and the following catalog.json is used as input for the LayerCatalog,

```json
{
  "catalog": [
      {
          "title": "Natuurnetwerk Nederland (NNN) - Provincies (INSPIRE geharmoniseerd) WMS",
          "resource": "wms:https://service.pdok.nl/provincies/natuurnetwerk-nederland/wms/v1_0#PS.ProtectedSite"
      }
    ]
}
```

then the configured service is accessed over HTTP and not (as configured) over HTTPS. The resulting redirect (302) from HTTP to HTTPS is causing CORS issues. 

This PR changes the behavior of the LayerCatalog to always just use the configured protocol.