### PR TITLE
Add configurable timeout to process notifications

### DIFF
--- a/actions/processNotifications.js
+++ b/actions/processNotifications.js
@@ -28,12 +28,13 @@ export function processStarted(id, name) {
     };
 }
 
-export function processFinished(id, success, message = "") {
+export function processFinished(id, success, message = "", timeout = true) {
     return {
         type: PROCESS_FINISHED,
         id,
         success,
-        message
+        message,
+        timeout
     };
 }
 

--- a/plugins/ProcessNotifications.jsx
+++ b/plugins/ProcessNotifications.jsx
@@ -47,15 +47,19 @@ class ProcessNotifications extends React.Component {
         if (process.status === ProcessStatus.BUSY) {
             icon = (<Spinner />);
         } else if (process.status === ProcessStatus.SUCCESS) {
-            setTimeout(() => {
-                this.props.clearProcess(process.id);
-            }, 7000);
+            if (process.timeout !== false) {
+                setTimeout(() => {
+                    this.props.clearProcess(process.id);
+                }, typeof process.timeout === 'number' ? process.timeout : 7000);
+            }
             icon = (<Icon icon="ok" />);
             close = true;
         } else if (process.status === ProcessStatus.FAILURE) {
-            setTimeout(() => {
-                this.props.clearProcess(process.id);
-            }, 12000);
+            if (process.timeout !== false) {
+                setTimeout(() => {
+                    this.props.clearProcess(process.id);
+                }, typeof process.timeout === 'number' ? process.timeout : 12000);
+            }
             icon = (<Icon icon="warning" />);
             close = true;
         }

--- a/reducers/processNotifications.js
+++ b/reducers/processNotifications.js
@@ -40,7 +40,8 @@ export default function processNotifications(state = defaultState, action) {
                 [action.id]: {
                     ...state.processes[action.id],
                     status: action.success ? ProcessStatus.SUCCESS : ProcessStatus.FAILURE,
-                    message: action.message
+                    message: action.message,
+                    timeout: action.timeout
                 }
             }
         };


### PR DESCRIPTION
Following PR #274. 

Configurable process notification's timeout. By default set to 'True', leaving the timeout times for clearing the process as they are, a number to set the desired time, and 'false' to not clear the process.
