### PR TITLE
Import zipped shapefile

### DIFF
--- a/components/ImportLayer.jsx
+++ b/components/ImportLayer.jsx
@@ -54,7 +54,10 @@ class ImportLayer extends React.Component {
         const urlPresets = ConfigUtils.getConfigProp("importLayerUrlPresets", this.props.theme) || [];
         if (this.state.type === "Local") {
             return (
-                <FileSelector accept=".kml,.json,.geojson,.pdf,.zip" file={this.state.file} onFileSelected={this.onFileSelected} />
+                <FileSelector
+                    accept=".kml,.json,.geojson,.pdf,.zip" file={this.state.file}
+                    onFileSelected={this.onFileSelected}
+                    title={LocaleUtils.tr("importlayer.supportedformats")} />
             );
         } else {
             return (

--- a/components/widgets/FileSelector.jsx
+++ b/components/widgets/FileSelector.jsx
@@ -23,7 +23,8 @@ export default class FileSelector extends React.Component {
         onFileSelected: PropTypes.func,
         onFilesSelected: PropTypes.func,
         overrideText: PropTypes.string,
-        showAllFilenames: PropTypes.bool
+        showAllFilenames: PropTypes.bool,
+        title: PropTypes.string
     };
     static defaultProps = {
         multiple: false,
@@ -59,8 +60,8 @@ export default class FileSelector extends React.Component {
         const placeholder = LocaleUtils.tr("fileselector.placeholder");
         return (
             <div className="FileSelector" onClick={this.triggerFileOpen}>
-                <input placeholder={placeholder} readOnly type="text" value={value} />
-                <button className="button">
+                <input placeholder={placeholder} readOnly title={this.props.title} type="text" value={value} />
+                <button className="button" title={this.props.title}>
                     <Icon icon="folder-open" />
                 </button>
                 <input accept={this.props.accept} multiple={this.props.multiple} onChange={this.fileChanged} ref={el => { this.fileinput = el; }} type="file" />

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "repository": "git@github.com:qgis/qwc2.git",
     "dependencies": {
         "@ladjs/country-language": "^1.0.3",
+        "@loaders.gl/core": "^4.2.0",
+        "@loaders.gl/shapefile": "^4.2.0",
+        "@loaders.gl/zip": "^4.2.0",
         "@reduxjs/toolkit": "^2.0.1",
         "@turf/buffer": "^6.5.0",
         "@turf/helpers": "^6.5.0",

--- a/scripts/themesConfig.js
+++ b/scripts/themesConfig.js
@@ -176,7 +176,7 @@ function getLayerTree(layer, resultLayers, visibleLayers, printLayers, level, co
         if (layer.Attribution) {
             layerEntry.attribution = {
                 Title: layer.Attribution.Title,
-                OnlineResource: layer.Attribution.OnlineResource ? layer.Attribution.OnlineResource.$["xlink:href"] : ""
+                OnlineResource: layer.Attribution.OnlineResource ? layer.Attribution.OnlineResource.$_href : ""
             };
         }
         if (layer.Abstract) {

--- a/translations/ca-ES.json
+++ b/translations/ca-ES.json
@@ -210,6 +210,7 @@
       "nofeatures": "No s'han pogut importar els elements.",
       "noresults": "Sense resultats o l'adreça URL no és vàlida",
       "notgeopdf": "",
+      "supportedformats": "",
       "unknownproj": "",
       "url": "URL",
       "urlplaceholder": "Adreça URL o WMS, WMTS, WFS..."

--- a/translations/cs-CZ.json
+++ b/translations/cs-CZ.json
@@ -210,6 +210,7 @@
       "nofeatures": "Žádné prvku nebyly importovány.",
       "noresults": "Bez výsledku nebo nevalidní URL",
       "notgeopdf": "",
+      "supportedformats": "",
       "unknownproj": "",
       "url": "URL",
       "urlplaceholder": "Vložit URL pro WMS, WMTS, WFS..."

--- a/translations/de-CH.json
+++ b/translations/de-CH.json
@@ -210,6 +210,7 @@
       "nofeatures": "Keine Objekte konnten importiert werden",
       "noresults": "Keine Resultate oder ungültige URL",
       "notgeopdf": "Die ausgewählte Datei scheint kein GeoPDF zu sein.",
+      "supportedformats": "",
       "unknownproj": "Das ausgewählte GeoPDF verwendet eine unbekannte Projektion: {0}.",
       "url": "URL",
       "urlplaceholder": "WMS, WMTS oder WFS URL eingeben..."

--- a/translations/de-DE.json
+++ b/translations/de-DE.json
@@ -210,6 +210,7 @@
       "nofeatures": "Keine Objekte konnten importiert werden",
       "noresults": "Keine Resultate oder ungültige URL",
       "notgeopdf": "Die ausgewählte Datei scheint kein GeoPDF zu sein.",
+      "supportedformats": "",
       "unknownproj": "Das ausgewählte GeoPDF verwendet eine unbekannte Projektion: {0}.",
       "url": "URL",
       "urlplaceholder": "WMS, WMTS oder WFS URL eingeben..."

--- a/translations/en-US.json
+++ b/translations/en-US.json
@@ -210,6 +210,7 @@
       "nofeatures": "No features could be imported.",
       "noresults": "No results or invalid URL",
       "notgeopdf": "The selected file does not seem to be a GeoPDF.",
+      "supportedformats": "Supported formats: KML, GeoJSON, GeoPDF, SHP (in zip)",
       "unknownproj": "The selected GeoPDF uses an unknown projection: {0}.",
       "url": "URL",
       "urlplaceholder": "Enter URL to WMS, WMTS, WFS..."

--- a/translations/es-ES.json
+++ b/translations/es-ES.json
@@ -210,6 +210,7 @@
       "nofeatures": "No se pudieron importar elementos.",
       "noresults": "Sin resultados o la dirección URL no es válida",
       "notgeopdf": "",
+      "supportedformats": "",
       "unknownproj": "",
       "url": "URL",
       "urlplaceholder": "Ingrese dirección URL o WMS, WMTS, WFS..."

--- a/translations/fi-FI.json
+++ b/translations/fi-FI.json
@@ -210,6 +210,7 @@
       "nofeatures": "Ominaisuustietoja ei voitu tuoda.",
       "noresults": "Tuloksia ei ole tai virheellinen URL-osoite",
       "notgeopdf": "",
+      "supportedformats": "",
       "unknownproj": "",
       "url": "URL",
       "urlplaceholder": "Anna rajapinnoille URL..."

--- a/translations/fr-FR.json
+++ b/translations/fr-FR.json
@@ -210,6 +210,7 @@
       "nofeatures": "Aucune entité ne peut être importée.",
       "noresults": "Pas de résultat ou URL non valide",
       "notgeopdf": "Le fichier sélectionné ne semble pas être un GeoPDF.",
+      "supportedformats": "Formats supportés: KML, GeoJSON, GeoPDF, SHP (zip)",
       "unknownproj": "Le GeoPDF sélectionné utilise une projection inconnue: {0}.",
       "url": "URL",
       "urlplaceholder": "Entrer l'URL d'un WMS, WMTS, WFS..."

--- a/translations/hu-HU.json
+++ b/translations/hu-HU.json
@@ -210,6 +210,7 @@
       "nofeatures": "Nem sikerült az importálás.",
       "noresults": "",
       "notgeopdf": "",
+      "supportedformats": "",
       "unknownproj": "",
       "url": "",
       "urlplaceholder": "URL a WMS, WMTS, WFS adatokhoz..."

--- a/translations/it-IT.json
+++ b/translations/it-IT.json
@@ -210,6 +210,7 @@
       "nofeatures": "Non è stato importato nessun oggetto ",
       "noresults": "Nessun risultato o URL non valido",
       "notgeopdf": "Il file selezionato non sembra essere un GeoPDF.",
+      "supportedformats": "",
       "unknownproj": "Il GeoPDF selezionato utilizza una proiezione sconosciuta: {0}",
       "url": "URL",
       "urlplaceholder": "Indirizzo WMS, WMTS, WFS..."

--- a/translations/no-NO.json
+++ b/translations/no-NO.json
@@ -210,6 +210,7 @@
       "nofeatures": "Ingen objekt kunne importeres",
       "noresults": "Ingen svar eller ugyldig URL",
       "notgeopdf": "",
+      "supportedformats": "",
       "unknownproj": "",
       "url": "URL",
       "urlplaceholder": "Skriv inn URL til WMS, WMTS, WFS..."

--- a/translations/pl-PL.json
+++ b/translations/pl-PL.json
@@ -210,6 +210,7 @@
       "nofeatures": "Elementy nie mogły zostać zaimportowane",
       "noresults": "Brak wyników lub błędny adres URL",
       "notgeopdf": "",
+      "supportedformats": "",
       "unknownproj": "",
       "url": "URL",
       "urlplaceholder": "Podaj URL do WMS, WFS, WMTS..."

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -210,6 +210,7 @@
       "nofeatures": "Nenhum recurso poder ser importado.",
       "noresults": "Sem resultados ou URL inválido",
       "notgeopdf": "",
+      "supportedformats": "",
       "unknownproj": "",
       "url": "URL",
       "urlplaceholder": "Insira o endereço URL do WMS, WMTS, WFS..."

--- a/translations/pt-PT.json
+++ b/translations/pt-PT.json
@@ -210,6 +210,7 @@
       "nofeatures": "Nenhuma característica poderia ser importada.",
       "noresults": "Sem resultados ou URL inválida",
       "notgeopdf": "Não é um ficheiro GeoPDF",
+      "supportedformats": "",
       "unknownproj": "Projeção Desconhecida",
       "url": "URL",
       "urlplaceholder": "Insira endereço URL ou WMS, WMTS, WFS..."

--- a/translations/ro-RO.json
+++ b/translations/ro-RO.json
@@ -210,6 +210,7 @@
       "nofeatures": "Nu s-a putut importa niciun obiect spațial",
       "noresults": "Fără rezultat sau adresă URL invalidă",
       "notgeopdf": "",
+      "supportedformats": "",
       "unknownproj": "",
       "url": "Adresă URL",
       "urlplaceholder": "Introduceți adresa URL către WMS, WMTS, WFS..."

--- a/translations/ru-RU.json
+++ b/translations/ru-RU.json
@@ -210,6 +210,7 @@
       "nofeatures": "Нет объектов, доступных для импорта",
       "noresults": "",
       "notgeopdf": "",
+      "supportedformats": "",
       "unknownproj": "",
       "url": "",
       "urlplaceholder": "Введите URL для WMS, WMTS, WFS..."

--- a/translations/sv-SE.json
+++ b/translations/sv-SE.json
@@ -210,6 +210,7 @@
       "nofeatures": "Inga objekt kunde importeras",
       "noresults": "Inget svar eller ogiltig URL",
       "notgeopdf": "",
+      "supportedformats": "",
       "unknownproj": "",
       "url": "URL",
       "urlplaceholder": "Skriv in URL till WMS, WMTS, WFS..."

--- a/translations/tr-TR.json
+++ b/translations/tr-TR.json
@@ -210,6 +210,7 @@
       "nofeatures": "Herhangi bir obje içeriye aktarılamadı.",
       "noresults": "Sonuç yok ya da geçersiz URL",
       "notgeopdf": "",
+      "supportedformats": "",
       "unknownproj": "",
       "url": "URL",
       "urlplaceholder": "WMS, WMTS, WFS Adresini giriniz..."

--- a/translations/tsconfig.json
+++ b/translations/tsconfig.json
@@ -193,6 +193,7 @@
     "importlayer.nofeatures",
     "importlayer.noresults",
     "importlayer.notgeopdf",
+    "importlayer.supportedformats",
     "importlayer.unknownproj",
     "importlayer.url",
     "importlayer.urlplaceholder",


### PR DESCRIPTION
Hi,

This PR aims to add SHP import in QWC. I have used [@loaders.gl](https://loaders.gl/) library to do so. User has to import ZIP file containing SHP file and sidecar files (shx, dbf, cpg, prj). There could be multiple SHP files in the ZIP.

I have also fixed a missing attribute which was not parsed using fast-xml-parser.

Thanks

_This feature has been funded by Grand Lyon Métropole https://www.grandlyon.com/_