### PR TITLE
Adjust BackgroundSwitcher items also according to splitscreen configuration

### DIFF
--- a/plugins/BackgroundSwitcher.jsx
+++ b/plugins/BackgroundSwitcher.jsx
@@ -77,13 +77,17 @@ class BackgroundSwitcher extends React.Component {
                 right: 'calc(1.5em + ' + right + 'px)',
                 bottom: 'calc(' + bottom + 'px + ' + (5 + 4 * this.props.position) + 'em)'
             };
+            const bgswitcherStyle = {
+                right: 'calc(5em + ' + right + 'px)',
+                bottom: 'calc(' + bottom + 'px + ' + (5 + 4 * this.props.position) + 'em)'
+            };
             return (
                 <div>
                     <button className={classes} onClick={this.buttonClicked}
                         style={style} title={tooltip}>
                         <Icon icon="bglayer" title={tooltip} />
                     </button>
-                    <div className={this.state.visible ? 'bgswitcher-active' : ''} id="BackgroundSwitcher">
+                    <div className={this.state.visible ? 'bgswitcher-active' : ''} id="BackgroundSwitcher" style={bgswitcherStyle}>
                         {this.renderLayerItem(null, backgroundLayers.filter(layer => layer.visibility === true).length === 0)}
                         {entries.map(entry => entry.group ? this.renderGroupItem(entry) : this.renderLayerItem(entry, entry.visibility === true))}
                     </div>


### PR DESCRIPTION
The items for changing the background layers are hidden by the open height profile window. Similarly to https://github.com/qgis/qwc2/commit/a196ae6e0bafe6564276667676fcc0d3cacc24f2 also adjust the items according to the splitscreen configuration.