### PR TITLE
Add translation for redlining draw layer

### DIFF
--- a/plugins/Redlining.jsx
+++ b/plugins/Redlining.jsx
@@ -78,7 +78,7 @@ class Redlining extends React.Component {
             if (vectorLayers.length >= 1) {
                 this.props.changeRedliningState({layer: vectorLayers[0].id, layerTitle: vectorLayers[0].title});
             } else if (this.props.redlining.layer !== 'redlining') {
-                this.props.changeRedliningState({layer: 'redlining', layerTitle: 'Redlining'});
+                this.props.changeRedliningState({layer: 'redlining', layerTitle: LocaleUtils.tr('redlining.drawlayer')});
             }
         }
     }
@@ -152,7 +152,7 @@ class Redlining extends React.Component {
         let vectorLayers = this.props.layers.filter(layer => layer.type === "vector" && layer.role === LayerRole.USERLAYER && !layer.readonly);
         // Ensure list always contains at least a "Redlining" layer
         if (vectorLayers.length === 0) {
-            vectorLayers = [{id: 'redlining', title: 'Redlining'}, ...vectorLayers];
+            vectorLayers = [{id: 'redlining', title: LocaleUtils.tr('redlining.drawlayer')}, ...vectorLayers];
         }
         const haveLayer = this.props.layers.find(l => l.id === this.props.redlining.layer) !== undefined;
 

--- a/plugins/map/RedliningSupport.jsx
+++ b/plugins/map/RedliningSupport.jsx
@@ -20,9 +20,10 @@ import NumericInputWindow from '../../components/NumericInputWindow';
 import {OlLayerAdded, OlLayerUpdated} from '../../components/map/OlLayer';
 import displayCrsSelector from '../../selectors/displaycrs';
 import FeatureStyles from '../../utils/FeatureStyles';
+import LocaleUtils from '../../utils/LocaleUtils';
 import MapUtils from '../../utils/MapUtils';
 import MeasureUtils from '../../utils/MeasureUtils';
-import LocaleUtils from '../../utils/LocaleUtils';
+
 
 const GeomTypeConfig = {
     Text: {drawInteraction: (opts) => new ol.interaction.Draw({...opts, type: "Point"}), editTool: 'Pick', drawNodes: true},

--- a/plugins/map/RedliningSupport.jsx
+++ b/plugins/map/RedliningSupport.jsx
@@ -22,6 +22,7 @@ import displayCrsSelector from '../../selectors/displaycrs';
 import FeatureStyles from '../../utils/FeatureStyles';
 import MapUtils from '../../utils/MapUtils';
 import MeasureUtils from '../../utils/MeasureUtils';
+import LocaleUtils from '../../utils/LocaleUtils';
 
 const GeomTypeConfig = {
     Text: {drawInteraction: (opts) => new ol.interaction.Draw({...opts, type: "Point"}), editTool: 'Pick', drawNodes: true},
@@ -574,7 +575,7 @@ class RedliningSupport extends React.Component {
         feature.crs = this.props.mapCrs;
         const layer = {
             id: this.props.redlining.layer,
-            title: this.props.redlining.layerTitle,
+            title: LocaleUtils.tr(this.props.redlining.layerTitle),
             role: LayerRole.USERLAYER,
             queryable: false
         };

--- a/plugins/map/RedliningSupport.jsx
+++ b/plugins/map/RedliningSupport.jsx
@@ -24,7 +24,6 @@ import LocaleUtils from '../../utils/LocaleUtils';
 import MapUtils from '../../utils/MapUtils';
 import MeasureUtils from '../../utils/MeasureUtils';
 
-
 const GeomTypeConfig = {
     Text: {drawInteraction: (opts) => new ol.interaction.Draw({...opts, type: "Point"}), editTool: 'Pick', drawNodes: true},
     Point: {drawInteraction: (opts) => new ol.interaction.Draw({...opts, type: "Point"}), editTool: 'Pick', drawNodes: true},

--- a/reducers/redlining.js
+++ b/reducers/redlining.js
@@ -18,7 +18,7 @@ const defaultState = {
         text: ""
     },
     layer: 'redlining',
-    layerTitle: 'Redlining',
+    layerTitle: 'redlining.drawlayer',
     selectedFeature: null,
     drawMultiple: true,
     measurements: false,

--- a/translations/ca-ES.json
+++ b/translations/ca-ES.json
@@ -380,6 +380,7 @@
       "circle": "Circle",
       "delete": "Eliminar",
       "draw": "Dibuixar",
+      "drawlayer": "",
       "edit": "Editar",
       "ellipse": "El·lipse",
       "freehand": "Dibuix a ma alçada",

--- a/translations/cs-CZ.json
+++ b/translations/cs-CZ.json
@@ -380,6 +380,7 @@
       "circle": "",
       "delete": "",
       "draw": "",
+      "drawlayer": "",
       "edit": "",
       "ellipse": "",
       "freehand": "",

--- a/translations/de-CH.json
+++ b/translations/de-CH.json
@@ -380,6 +380,7 @@
       "circle": "Kreis",
       "delete": "Löschen",
       "draw": "Zeichnen",
+      "drawlayer": "",
       "edit": "Bearbeiten",
       "ellipse": "Ellipse",
       "freehand": "Freihand",

--- a/translations/de-DE.json
+++ b/translations/de-DE.json
@@ -380,6 +380,7 @@
       "circle": "Kreis",
       "delete": "Löschen",
       "draw": "Zeichnen",
+      "drawlayer": "",
       "edit": "Bearbeiten",
       "ellipse": "Ellipse",
       "freehand": "Freihand",

--- a/translations/en-US.json
+++ b/translations/en-US.json
@@ -380,6 +380,7 @@
       "circle": "Circle",
       "delete": "Delete",
       "draw": "Draw",
+      "drawlayer": "Redlining",
       "edit": "Edit",
       "ellipse": "Ellipse",
       "freehand": "Freehand drawing",

--- a/translations/es-ES.json
+++ b/translations/es-ES.json
@@ -380,6 +380,7 @@
       "circle": "Círculo",
       "delete": "Eliminar",
       "draw": "Dibujar",
+      "drawlayer": "",
       "edit": "Editar",
       "ellipse": "Elipse",
       "freehand": "Dibujo a mano alzada",

--- a/translations/fi-FI.json
+++ b/translations/fi-FI.json
@@ -380,6 +380,7 @@
       "circle": "Ympyrä",
       "delete": "Poista",
       "draw": "Piirrä",
+      "drawlayer": "",
       "edit": "Editoi",
       "ellipse": "",
       "freehand": "Vapaa piirto",

--- a/translations/fr-FR.json
+++ b/translations/fr-FR.json
@@ -380,6 +380,7 @@
       "circle": "Cercle",
       "delete": "Effacer",
       "draw": "Dessiner",
+      "drawlayer": "Dessin",
       "edit": "Editer",
       "ellipse": "Ellipse",
       "freehand": "Dessin à main libre",

--- a/translations/hu-HU.json
+++ b/translations/hu-HU.json
@@ -380,6 +380,7 @@
       "circle": "",
       "delete": "",
       "draw": "",
+      "drawlayer": "",
       "edit": "",
       "ellipse": "",
       "freehand": "",

--- a/translations/it-IT.json
+++ b/translations/it-IT.json
@@ -380,6 +380,7 @@
       "circle": "Cerchio",
       "delete": "Elimina",
       "draw": "Disegna",
+      "drawlayer": "",
       "edit": "Modifica",
       "ellipse": "Ellisse",
       "freehand": "Mano libera",

--- a/translations/no-NO.json
+++ b/translations/no-NO.json
@@ -380,6 +380,7 @@
       "circle": "",
       "delete": "Slett",
       "draw": "Tegn",
+      "drawlayer": "",
       "edit": "Rediger",
       "ellipse": "",
       "freehand": "Frihånd",

--- a/translations/pl-PL.json
+++ b/translations/pl-PL.json
@@ -380,6 +380,7 @@
       "circle": "",
       "delete": "Usuń",
       "draw": "Rysuj",
+      "drawlayer": "",
       "edit": "Edytuj",
       "ellipse": "",
       "freehand": "",

--- a/translations/pt-BR.json
+++ b/translations/pt-BR.json
@@ -380,6 +380,7 @@
       "circle": "Círculo",
       "delete": "Excluir",
       "draw": "Traçar",
+      "drawlayer": "",
       "edit": "Editar",
       "ellipse": "Elipse",
       "freehand": "Desenho à mão livre ",

--- a/translations/pt-PT.json
+++ b/translations/pt-PT.json
@@ -380,6 +380,7 @@
       "circle": "Círculo",
       "delete": "Excluir",
       "draw": "Desenhar",
+      "drawlayer": "",
       "edit": "Editar",
       "ellipse": "Elipse",
       "freehand": "Desenho à mão livre",

--- a/translations/ro-RO.json
+++ b/translations/ro-RO.json
@@ -380,6 +380,7 @@
       "circle": "Cerc",
       "delete": "Elimină",
       "draw": "Desenare",
+      "drawlayer": "",
       "edit": "Modifică",
       "ellipse": "Elipsă",
       "freehand": "Desen liber",

--- a/translations/ru-RU.json
+++ b/translations/ru-RU.json
@@ -380,6 +380,7 @@
       "circle": "",
       "delete": "",
       "draw": "",
+      "drawlayer": "",
       "edit": "",
       "ellipse": "",
       "freehand": "",

--- a/translations/sv-SE.json
+++ b/translations/sv-SE.json
@@ -380,6 +380,7 @@
       "circle": "",
       "delete": "Radera",
       "draw": "Rita",
+      "drawlayer": "",
       "edit": "Redigera",
       "ellipse": "",
       "freehand": "",

--- a/translations/tr-TR.json
+++ b/translations/tr-TR.json
@@ -380,6 +380,7 @@
       "circle": "Daire",
       "delete": "Sil",
       "draw": "Çiz",
+      "drawlayer": "",
       "edit": "Düzenle",
       "ellipse": "Elips",
       "freehand": "Serbest çizim",

--- a/translations/tsconfig.json
+++ b/translations/tsconfig.json
@@ -317,6 +317,7 @@
     "redlining.circle",
     "redlining.delete",
     "redlining.draw",
+    "redlining.drawlayer",
     "redlining.edit",
     "redlining.ellipse",
     "redlining.freehand",


### PR DESCRIPTION
Hello @manisandro,

I would like to submit this PR because I received feedback from many users who don't understand why the default redlining layer is named like this, even in other languages. It can be confusing for people who don't understand basic English.

So, this PR aims to use the translation tools to name the layer according to the user's browser language. I hope the code is correct, but please let me know if it isn't.

Thanks in advance,
Regards, Clément.