### PR TITLE
Customizable providers label through theme config.

### DIFF
--- a/selectors/searchproviders.js
+++ b/selectors/searchproviders.js
@@ -40,6 +40,8 @@ export default (searchProviders) => createSelector(
                 providerKeys.add(key);
                 availableProviders[key] = {
                     ...provider,
+                    label: entry.label ?? provider.label,
+                    labelmsgid: entry.labelmsgid ?? provider.labelmsgid,
                     params: entry.params
                 };
             }


### PR DESCRIPTION
Allow the configuration of a provider in the theme to override the `label` or `labelmsgid`.