### PR TITLE
Using theme id instead of name as filename for print and map export

### DIFF
--- a/plugins/MapExport.jsx
+++ b/plugins/MapExport.jsx
@@ -170,7 +170,7 @@ class MapExport extends React.Component {
                 <input min="1" onChange={ev => this.setState({scale: ev.target.value})} role="input" type="number" value={this.state.scale} />
             );
         }
-        const filename = this.props.theme.name.split("/").pop() + "." + this.state.selectedFormat.split(";")[0].split("/").pop();
+        const filename = this.props.theme.id.split("/").pop() + "." + this.state.selectedFormat.split(";")[0].split("/").pop();
         const action = this.props.theme.url;
         const exportExternalLayers = this.state.selectedFormat !== "application/dxf" && this.props.exportExternalLayers && ConfigUtils.getConfigProp("qgisServerVersion") >= 3;
 
@@ -412,7 +412,7 @@ class MapExport extends React.Component {
             this.setState({exporting: false});
             const contentType = response.headers["content-type"];
             const ext = this.state.selectedFormat.split(";")[0].split("/").pop();
-            FileSaver.saveAs(new Blob([response.data], {type: contentType}), this.props.theme.name + '.' + ext);
+            FileSaver.saveAs(new Blob([response.data], {type: contentType}), this.props.theme.id + '.' + ext);
         }).catch(e => {
             this.setState({exporting: false});
             if (e.response) {

--- a/plugins/Print.jsx
+++ b/plugins/Print.jsx
@@ -508,7 +508,7 @@ class Print extends React.Component {
         );
     };
     savePrintOutput = () => {
-        FileSaver.saveAs(this.state.pdfData, this.props.theme.name + '.pdf');
+        FileSaver.saveAs(this.state.pdfData, this.props.theme.id + '.pdf');
     };
     render() {
         const minMaxTooltip = this.state.minimized ? LocaleUtils.tr("print.maximize") : LocaleUtils.tr("print.minimize");
@@ -625,7 +625,7 @@ class Print extends React.Component {
                 this.setState({ pdfData: file, pdfDataUrl: fileURL, outputLoaded: true });
             } else {
                 const ext = this.state.selectedFormat.split(";")[0].split("/").pop();
-                FileSaver.saveAs(file, this.props.theme.name + '.' + ext);
+                FileSaver.saveAs(file, this.props.theme.id + '.' + ext);
             }
         }).catch(e => {
             this.setState({printing: false, outputLoaded: true, printOutputVisible: false});


### PR DESCRIPTION
AS mentioned in [1] this prevents, that `pg_schemaname` is part of the filename, if the QGIS project is stored in database.

[1] https://github.com/qgis/qwc2-demo-app/issues/580#issuecomment-2352218604