### PR TITLE
Add an option to disable automatic zoom in routing plugin 

### DIFF
--- a/plugins/Routing.jsx
+++ b/plugins/Routing.jsx
@@ -813,7 +813,7 @@ class Routing extends React.Component {
                 }));
                 this.props.addLayerFeatures(layer, features, true);
                 if (this.props.zoomAuto) {
-                    this.props.zoomToExtent(result.summary.bounds, "EPSG:4326", -0.5);
+                    this.props.zoomToExtent(result.bounds, "EPSG:4326", -0.5);
                   }
             }
             this.updateIsoConfig({result: {success, data: result}, busy: false}, false);

--- a/plugins/Routing.jsx
+++ b/plugins/Routing.jsx
@@ -60,6 +60,8 @@ class Routing extends React.Component {
             initiallyDocked: PropTypes.bool,
             side: PropTypes.string
         }),
+        /** Automatic zoom to the extent of the location. */
+        zoomAuto: PropTypes.bool,
         layers: PropTypes.array,
         locatePos: PropTypes.array,
         mapcrs: PropTypes.string,
@@ -83,6 +85,7 @@ class Routing extends React.Component {
             initiallyDocked: true,
             side: 'left'
         },
+        zoomAuto: true,
         showPinLabels: true
     };
     state = {
@@ -766,7 +769,9 @@ class Routing extends React.Component {
                 });
                 this.updateRouteConfig({points: reorderedPoints, result: {success, data: result}, busy: false}, false);
 
-                this.props.zoomToExtent(result.summary.bounds, "EPSG:4326", -1);
+                if (this.props.zoomAuto) {
+                    this.props.zoomToExtent(result.summary.bounds, "EPSG:4326", -0.5);
+                  }
             } else {
                 this.updateRouteConfig({result: {success, data: result}, busy: false}, false);
             }
@@ -807,7 +812,9 @@ class Routing extends React.Component {
                     }
                 }));
                 this.props.addLayerFeatures(layer, features, true);
-                this.props.zoomToExtent(result.bounds, "EPSG:4326", -0.5);
+                if (this.props.zoomAuto) {
+                    this.props.zoomToExtent(result.summary.bounds, "EPSG:4326", -0.5);
+                  }
             }
             this.updateIsoConfig({result: {success, data: result}, busy: false}, false);
         });

--- a/plugins/Routing.jsx
+++ b/plugins/Routing.jsx
@@ -770,7 +770,7 @@ class Routing extends React.Component {
                 this.updateRouteConfig({points: reorderedPoints, result: {success, data: result}, busy: false}, false);
 
                 if (this.props.zoomAuto) {
-                    this.props.zoomToExtent(result.summary.bounds, "EPSG:4326", -0.5);
+                    this.props.zoomToExtent(result.summary.bounds, "EPSG:4326", -1);
                   }
             } else {
                 this.updateRouteConfig({result: {success, data: result}, busy: false}, false);


### PR DESCRIPTION
Hello @manisandro,

I would like to submit this PR to add an option in the routing plugin to disable automatic zoom.

In some use cases, it could be more convenient for the user to keep the map from adjusting to the calculated road extent. For example, if they want to add another point farther away or if they have other elements on the map and do not want the scale to change.

I will update the documentation accordingly if this is approved.

Please feel free to share any feedback.

Kind regards,
Clément