### PR TITLE
Restore clickable buttons on touch devices

### DIFF
--- a/components/ResizeableWindow.jsx
+++ b/components/ResizeableWindow.jsx
@@ -303,7 +303,7 @@ class ResizeableWindow extends React.Component {
         }
         return (
             <div className="resizeable-window-container" key="InternalWindow" style={containerStyle}>
-                <Rnd bounds="parent"
+                <Rnd bounds="parent" cancel=".resizeable-window-titlebar-control"
                     className={windowclasses} default={this.state.geometry}
                     disableDragging={maximized || this.state.geometry.docked} enableResizing={resizeMode}
                     maxHeight={this.props.maxHeight || window.innerHeight} maxWidth={this.props.maxWidth || window.innerWidth}


### PR DESCRIPTION
The `cancel` attribute got removed in a previous commit, removing the ability to close popup windows on mobile and touch devices.