### PR TITLE
Build filter from array

### DIFF
--- a/utils/LayerUtils.js
+++ b/utils/LayerUtils.js
@@ -224,6 +224,8 @@ const LayerUtils = {
                 return `"${expr[0]}" ${op} ${expr[2]}`;
             } else if (expr[2] === null) {
                 return `"${expr[0]}" ${op} NULL`;
+            } else if (Array.isArray(expr[2]) ){
+                return `"${expr[0]}" ${op} ( ${expr[2].join(' , ')} )`;
             } else {
                 return `"${expr[0]}" ${op} '${expr[2]}'`;
             }

--- a/utils/LayerUtils.js
+++ b/utils/LayerUtils.js
@@ -224,7 +224,7 @@ const LayerUtils = {
                 return `"${expr[0]}" ${op} ${expr[2]}`;
             } else if (expr[2] === null) {
                 return `"${expr[0]}" ${op} NULL`;
-            } else if (Array.isArray(expr[2])){
+            } else if (Array.isArray(expr[2])) {
                 return `"${expr[0]}" ${op} ( ${expr[2].join(' , ')} )`;
             } else {
                 return `"${expr[0]}" ${op} '${expr[2]}'`;

--- a/utils/LayerUtils.js
+++ b/utils/LayerUtils.js
@@ -224,7 +224,7 @@ const LayerUtils = {
                 return `"${expr[0]}" ${op} ${expr[2]}`;
             } else if (expr[2] === null) {
                 return `"${expr[0]}" ${op} NULL`;
-            } else if (Array.isArray(expr[2]) ){
+            } else if (Array.isArray(expr[2])){
                 return `"${expr[0]}" ${op} ( ${expr[2].join(' , ')} )`;
             } else {
                 return `"${expr[0]}" ${op} '${expr[2]}'`;


### PR DESCRIPTION
Hi, I wanted to set a WMS filter from `["muni_id", "IN", muniFilter]` where **muniFilter** is an array. With the the following WMS documentation in mind:

`Text strings need to be enclosed with quotes (single quotes for strings, double quotes for attributes) A space between each word / special character is mandatory. Allowed Keywords and special characters are ‘AND’,’OR’,’IN’,’=’,’<’,’>=’, ‘>’,’>=’,’!=*,’(‘,’)’. Semicolons in string expressions are not allowed`

And with the result filter I needed `"muni_id" IN ( 1 , 2 ) `,  I added the case to format the filter accordingly.

I suppose there is a better way to do it? Please let me know.

Thanks!