### PR TITLE
Japanese translation corrected.

### DIFF
--- a/translations/ja-JP.json
+++ b/translations/ja-JP.json
@@ -506,7 +506,7 @@
       "nodescription": "説明がありません",
       "none": "無し",
       "noresults": "検索結果無し",
-      "placeholder": "場所を検索、または地図を追加...",
+      "placeholder": "テーマとレイヤを検索して選択または追加...",
       "places": "場所",
       "providerselection": "検索プロバイダ",
       "recent": "最近の検索",


### PR DESCRIPTION
Corrected Japanse translation for "search.placeholder".

Its counterpart in 'en-US.json' is currently "Search place or add map...", but I don't think it's suitable for the use case in 'searchBox' in the 'TopBar'. So I've given a Japanese translation for something like "Search themes and layers to select or add...".

Or, "search.placeholder" has other use cases ? Then tell me so, and I will withdraw the PR.