### PR TITLE
Enhance WMTS imports by handling styles and tile matrices per layer

### DIFF
--- a/components/map/layers/WMTSLayer.js
+++ b/components/map/layers/WMTSLayer.js
@@ -30,7 +30,7 @@ export function createWMTSSource(options) {
     const matrixIds = new Array(options.resolutions.length);
     // generate matrixIds arrays for this WMTS
     for (let z = 0; z < options.resolutions.length; ++z) {
-        matrixIds[z] = options.tileMatrixPrefix + z;
+        matrixIds[z] = options.tileMatrixPrefix !== "" ? options.tileMatrixPrefix + ":" + z : z;
     }
     const extent = options.bbox ? CoordinatesUtils.reprojectBbox(options.bbox.bounds, options.bbox.crs, options.projection) : null;
 

--- a/utils/ServiceLayerUtils.js
+++ b/utils/ServiceLayerUtils.js
@@ -10,6 +10,8 @@ import axios from 'axios';
 import deepmerge from 'deepmerge';
 import {XMLParser} from 'fast-xml-parser';
 import isEmpty from 'lodash.isempty';
+import { getWidth } from 'ol/extent';
+import { get as getProjection } from 'ol/proj';
 import ol from 'openlayers';
 import randomColor from 'randomcolor';
 import url from 'url';
@@ -45,9 +47,44 @@ const ServiceLayerUtils = {
             return res;
         }, {});
         const layers = capabilities.Contents.Layer.map(layer => {
-            const matchingMatrix = layer.TileMatrixSetLink.find(link => tileMatrices[link.TileMatrixSet].crs === mapCrs);
-            const tileMatrixSet = matchingMatrix ? matchingMatrix.TileMatrixSet : layer.TileMatrixSetLink[0].TileMatrixSet;
+            const styles = this.getWMTSLayerStyles(capabilities, capabilitiesUrl, layer, tileMatrices);
+            return {
+                capabilitiesUrl: capabilitiesUrl,
+                title: layer.Title,
+                name: layer.Identifier,
+                bbox: {
+                    crs: "EPSG:4326",
+                    bounds: layer.WGS84BoundingBox
+                },
+                sublayers: styles,
+                abstract: layer.Abstract,
+                attribution: {
+                    Title: capabilities.ServiceProvider?.ProviderName || capabilities.ServiceIdentification?.Title || "",
+                    OnlineResource: capabilities.ServiceProvider?.ProviderSite || ""
+                }
+            };
+        });
+        layers.sort((a, b) => a.title.localeCompare(b.title));
+        return layers;
+    },
+    getWMTSLayerStyles(capabilities, capabilitiesUrl, layer, tileMatrices) {
+        if (layer.Style.length === 1) {
+            return this.getWMTSLayerTileMatrixSetLinks(capabilities, capabilitiesUrl, layer, tileMatrices, layer.Style[0].Identifier);
+        } else {
+            return layer.Style.map(style => {
+                return {
+                    title: style.Identifier,
+                    sublayers: this.getWMTSLayerTileMatrixSetLinks(capabilities, capabilitiesUrl, layer, tileMatrices, style.Identifier)
+                };
+            });
+        }
+    },
+    getWMTSLayerTileMatrixSetLinks(capabilities, capabilitiesUrl, layer, tileMatrices, style) {
+        const tileMatrixSetLinks = layer.TileMatrixSetLink;
+        const layerLinks = tileMatrixSetLinks.map(link => {
+            const tileMatrixSet = link.TileMatrixSet;
             const topMatrix = tileMatrices[tileMatrixSet].matrix[0];
+            const tileMatrixPrefix = topMatrix.Identifier.includes(":") ? topMatrix.Identifier.replace(/:[0-9]+$/, "") : "";
             let origin = [topMatrix.TopLeftCorner[0], topMatrix.TopLeftCorner[1]];
             try {
                 const axisOrder = CoordinatesUtils.getAxisOrder(tileMatrices[tileMatrixSet].crs).substr(0, 2);
@@ -59,12 +96,14 @@ const ServiceLayerUtils = {
                 console.warn("Could not determine axis order for projection " + tileMatrices[tileMatrixSet].crs);
                 return null;
             }
-            const resolutions = tileMatrices[tileMatrixSet].matrix.map(entry => {
+            // https://openlayers.org/en/latest/examples/wmts-ign.html
+            const proj = getProjection(tileMatrices[tileMatrixSet].crs);
+            const maxResolution = proj?.getExtent() ? getWidth(proj?.getExtent()) / topMatrix.TileWidth : null;
+            const resolutions = tileMatrices[tileMatrixSet].matrix.map((entry, index) => {
                 // 0.00028: assumed pixel width in meters, as per WMTS standard
-                return entry.ScaleDenominator * 0.00028;
+                return maxResolution ? maxResolution / Math.pow(2, index) : entry.ScaleDenominator * 0.00028;
             });
-            const styles = MiscUtils.ensureArray(layer.Style || []);
-            const style = (styles.find(entry => entry.isDefault) || styles[0] || {Identifier: ""}).Identifier;
+            const format = MiscUtils.ensureArray(layer.Format).find(fmt => fmt === "image/jpeg") ?? MiscUtils.ensureArray(layer.Format)[0];
             const getTile = MiscUtils.ensureArray(capabilities.OperationsMetadata.GetTile.DCP.HTTP.Get)[0];
             const getEncoding = MiscUtils.ensureArray(getTile.Constraint).find(c => c.name === "GetEncoding");
             const requestEncoding = MiscUtils.ensureArray(getEncoding.AllowedValues.Value)[0];
@@ -81,9 +120,9 @@ const ServiceLayerUtils = {
                 type: "wmts",
                 url: serviceUrl,
                 capabilitiesUrl: capabilitiesUrl,
-                title: layer.Title,
+                title: layer.Title + " - " + tileMatrixSet,
                 name: layer.Identifier,
-                tileMatrixPrefix: "",
+                tileMatrixPrefix: tileMatrixPrefix,
                 tileMatrixSet: tileMatrixSet,
                 originX: origin[0],
                 originY: origin[1],
@@ -97,7 +136,7 @@ const ServiceLayerUtils = {
                     crs: "EPSG:4326",
                     bounds: layer.WGS84BoundingBox
                 },
-                format: MiscUtils.ensureArray(layer.Format)[0],
+                format: format,
                 requestEncoding: requestEncoding,
                 resolutions: resolutions,
                 abstract: layer.Abstract,
@@ -107,8 +146,7 @@ const ServiceLayerUtils = {
                 }
             };
         }).filter(Boolean);
-        layers.sort((a, b) => a.title.localeCompare(b.title));
-        return layers;
+        return layerLinks;
     },
     getWMSLayers(capabilities, calledServiceUrl, asGroup = false) {
         if (!capabilities?.WMS_Capabilities && !capabilities?.WMT_MS_Capabilities) {

--- a/utils/ServiceLayerUtils.js
+++ b/utils/ServiceLayerUtils.js
@@ -103,7 +103,7 @@ const ServiceLayerUtils = {
                 // 0.00028: assumed pixel width in meters, as per WMTS standard
                 return maxResolution ? maxResolution / Math.pow(2, index) : entry.ScaleDenominator * 0.00028;
             });
-            const format = MiscUtils.ensureArray(layer.Format).find(fmt => fmt === "image/jpeg") ?? MiscUtils.ensureArray(layer.Format)[0];
+            const format = MiscUtils.ensureArray(layer.Format).find(fmt => fmt === "image/png") ?? MiscUtils.ensureArray(layer.Format)[0];
             const getTile = MiscUtils.ensureArray(capabilities.OperationsMetadata.GetTile.DCP.HTTP.Get)[0];
             const getEncoding = MiscUtils.ensureArray(getTile.Constraint).find(c => c.name === "GetEncoding");
             const requestEncoding = MiscUtils.ensureArray(getEncoding.AllowedValues.Value)[0];


### PR DESCRIPTION
Hi,

Currently, I do not manage to use some WMTS services correctly :
* Grand Lyon (https://imagerie.data.grandlyon.com/geoserver/grandlyon/gwc/service/wmts?REQUEST=GetCapabilities)
* Grand Est (https://www.datagrandest.fr/geoserver/gwc/service/wmts?REQUEST=GetCapabilities)
* IGN (https://data.geopf.fr/wmts?SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities)

Requests are not the right ones because `TileMatrix` parameter is wrong due to `TileMatrixSet.TileMatrix.Identifier`

For instance, when adding a layer from Grand Lyon using the demo app : https://imagerie.data.grandlyon.com/geoserver/grandlyon/gwc/service/wmts?layer=TS2011_nuit&style=raster&tilematrixset=EPSG%3A4326&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix=21&TileCol=19&TileRow=4 raises an error `Unknown TILEMATRIX 21`

When requesting GetCapabilities, TileMatrixSet.TileMatrix.Identifier is not a simple incremental number but `EPSG:3946:0` so we have to handle this prefix to build the request.

Also, there could be multiple styles, multiple tile matrices and formats by layer. So the layer currently displayed in the app right now could not be working.

There was also an issue regarding resolutions that have to be computed regarding max resolution (see [OpenLayers example on WMTS](https://openlayers.org/en/latest/examples/wmts.html)).

I tried to manage multiple styles and tile matrices with `sublayers` to be expanded. For now, I search for `image/jpeg` format or fallback to the first format returned in capabilities. This could be improved later if we want to handle multiple formats.

![image](https://github.com/user-attachments/assets/416358d2-76cd-4537-8448-c818bd769736)

![image](https://github.com/user-attachments/assets/492027a5-708d-4503-9bd8-75d05291a66b)

The default preset (Swisstopo https://wmts10.geo.admin.ch/EPSG/2056/1.0.0/WMTSCapabilities.xml) is still working with this adding.

Maybe there are still remaining issues on specific cases (i.e EPSG:4326 that is not working, and maybe other layers) but I think the situation is better than it was regarding the 3 french examples that I used. Specific cases could be treated later.

Please tell me what you think about it.

Thanks

Benoît
