### PR TITLE
fixed logged in user name z-index

### DIFF
--- a/plugins/style/Authentication.css
+++ b/plugins/style/Authentication.css
@@ -1,5 +1,6 @@
 div.login-user {
     position: fixed;
+    z-index: 2;
     right: 0.25em;
     top: var(--topbar-height);
     color: var(--panel-text-color);


### PR DESCRIPTION
As logged-in user name widget had no z-index setting, it was hidden behind the map image.
Now it has the same z-index as map buttons and hovers over the map image.

Corresponding issue in `qwc2-demo-app`
- https://github.com/qgis/qwc2-demo-app/issues/608