### PR TITLE
Fix missing BBOX parameter in Identify region

### DIFF
--- a/utils/IdentifyUtils.js
+++ b/utils/IdentifyUtils.js
@@ -137,6 +137,7 @@ const IdentifyUtils = {
             height: size[0],
             width: size[1],
             feature_count: 100,
+            bbox: map.bbox.bounds.join(","),
             FILTER_GEOM: filterGeom,
             ...options
         };


### PR DESCRIPTION
Hello @manisandro,

This update addresses the missing BBOX parameter in the Identify Region plugin (#399) and other plugins such as snapping, reporting, TimeManager, and PickFeature.

I believe it's better to add the parameter globally since, ultimately, you want to select only what is visible on the map—but I might be wrong.

Please let me know if there are any issues.

Best regards,
Clément