### PR TITLE
Set version to 2025.03.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "qwc2",
-    "version": "2025.03.27",
+    "version": "2025.03.31",
     "description": "QGIS Web Client",
     "author": "Sourcepole AG",
     "license": "BSD-2-Clause",


### PR DESCRIPTION
Hello @manisandro, is it possible to push a tag `v2025.03.31` so the qwc-map-viewer image can be built successfully please ?

Thanks