### PR TITLE
Make external layer configuration more robust and customizable

### DIFF
--- a/reducers/layers.js
+++ b/reducers/layers.js
@@ -315,7 +315,10 @@ export default function layers(state = defaultState, action) {
                         ...action.layer,
                         role: layer.role,
                         id: layer.id,
-                        uuid: layer.uuid
+                        uuid: layer.uuid,
+                        // keep original title and attribution
+                        title: layer.title || action.layer.title,
+                        attribution: layer.attribution || action.layer.attribution
                     };
                     delete newLayer.loading;
                     LayerUtils.addUUIDs(newLayer);

--- a/utils/ServiceLayerUtils.js
+++ b/utils/ServiceLayerUtils.js
@@ -104,9 +104,9 @@ const ServiceLayerUtils = {
                 return maxResolution ? maxResolution / Math.pow(2, index) : entry.ScaleDenominator * 0.00028;
             });
             const format = MiscUtils.ensureArray(layer.Format).find(fmt => fmt === "image/png") ?? MiscUtils.ensureArray(layer.Format)[0];
-            const getTile = MiscUtils.ensureArray(capabilities.OperationsMetadata.GetTile.DCP.HTTP.Get)[0];
-            const getEncoding = MiscUtils.ensureArray(getTile.Constraint).find(c => c.name === "GetEncoding");
-            const requestEncoding = MiscUtils.ensureArray(getEncoding.AllowedValues.Value)[0];
+            const getTile = MiscUtils.ensureArray(capabilities.OperationsMetadata?.GetTile?.DCP?.HTTP?.Get)[0];
+            const getEncoding = MiscUtils.ensureArray(getTile?.Constraint).find(c => c.name === "GetEncoding");
+            const requestEncoding = MiscUtils.ensureArray(getEncoding?.AllowedValues.Value)[0];
             let serviceUrl = null;
             if (requestEncoding === 'KVP') {
                 serviceUrl = getTile.href;


### PR DESCRIPTION
This pull request includes two minor changes:

The patch in `ServiceLayerUtils.js` prevents crashes when the `OperationsMetadata` element is not available in the `GetCapabilities` response of a WMTS Server.

The patch in `layers.js` allows the user to define a custom title and attribution for background layers in `themesConfig.json` to override the response from the WTMS Server.