### PR TITLE
Allow to disable themes in configuration

### DIFF
--- a/scripts/themesConfig.js
+++ b/scripts/themesConfig.js
@@ -278,6 +278,12 @@ function flatLayers(layer) {
 
 // parse GetCapabilities for theme
 function getTheme(config, configItem, result, resultItem, proxy) {
+    if (configItem.disabled) {
+        /* eslint-disable-next-line no-console */
+        console.log(`Item ${configItem.url}` + (configItem.title ? ` (${configItem.title})` : "") + " has been disabled");
+        return;
+    }
+
     const parsedUrl = urlUtil.parse(urlUtil.resolve(hostFqdn, configItem.url), true);
     parsedUrl.search = '';
     parsedUrl.query.SERVICE = "WMS";
@@ -302,7 +308,7 @@ function getTheme(config, configItem, result, resultItem, proxy) {
             }
 
             /* eslint-disable-next-line */
-            console.log("Parsing WMS GetProjectSettings of " + configItem.url);
+            console.log("Parsing WMS GetProjectSettings of " + configItem.url + (configItem.title ? ` (${configItem.title})` : ""));
 
             const topLayer = capabilities.Capability.Layer;
             const wmsName = configItem.url.replace(/.*\//, '').replace(/\?^/, '');

--- a/scripts/themesConfig.py
+++ b/scripts/themesConfig.py
@@ -294,6 +294,9 @@ def getLayerTree(layer, resultLayers, visibleLayers, printLayers, level, collaps
 # parse GetCapabilities for theme
 def getTheme(config, configItem, result, resultItem):
     global autogenExternalLayers
+    if (configItem.get("disabled", False)):
+        print(f"Item {configItem.get("url")} {"(" + configItem.get("title") + ")" if configItem.get("title") else ""} has been disabled")
+        return
 
     url = update_params(urljoin(baseUrl, configItem["url"]), {'SERVICE': 'WMS', 'VERSION': '1.3.0', 'REQUEST': 'GetProjectSettings'})
 
@@ -302,7 +305,7 @@ def getTheme(config, configItem, result, resultItem):
         reply = opener(url).read()
         capabilities = parseString(reply)
         capabilities = capabilities.getElementsByTagName("WMS_Capabilities")[0]
-        print("Parsing WMS GetProjectSettings of " + configItem["url"])
+        print(f"Parsing WMS GetProjectSettings of {configItem.get("url")} {"(" + configItem.get("title") + ")" if configItem.get("title") else ""}")
 
         topLayer = getChildElement(getChildElement(capabilities, "Capability"), "Layer")
         wmsName = re.sub(r".*/", "", configItem["url"]).rstrip("?")


### PR DESCRIPTION
Hi,

This PR allows user to disable temporarily some themes in configuration to be able to access to the application despite some themes not well configured (bad layers, external layers not available, ...).

I will create an other PR in qwc-config-generator and qwc-admin-gui services to handle this feature.

This is funded by [Eurométropole de Strasbourg](https://www.strasbourg.eu/).

Thanks for the review