### PR TITLE
Update Print.jsx

### DIFF
--- a/plugins/Print.jsx
+++ b/plugins/Print.jsx
@@ -86,9 +86,7 @@ class Print extends React.Component {
         /** All layouts with this prefix will not be displayed in the print layoutlist */
         hidePrintlayoutPrefix: PropTypes.string,
         /** Alphabetical order for print layouts: asc or desc */
-        sortPrintlayouts: PropTypes.string,
-        /** The default layout to display first */
-        defaultPrintlayout: PropTypes.string
+        sortPrintlayouts: PropTypes.string
     };
     static defaultProps = {
         defaultDpi: 300,
@@ -103,8 +101,7 @@ class Print extends React.Component {
         printMapHighlights: true,
         scaleFactor: 1.9, // Experimentally determined...
         side: 'right',
-        sortPrintlayouts: 'desc',
-        defaultPrintlayout: ''
+        sortPrintlayouts: 'desc'
     };
     state = {
         center: null,
@@ -154,7 +151,7 @@ class Print extends React.Component {
                         return b.name.split('/').pop().localeCompare(a.name.split('/').pop(), undefined, {numeric: true});
                     });
                 }
-                const layout = layouts.find(l => l.default || l.name == this.props.defaultPrintlayout) || layouts[0];
+                const layout = layouts.find(l => l.default) || layouts[0];
                 this.setState({layouts: layouts, layout: layout, atlasFeatures: []});
             } else {
                 this.setState({layouts: [], layout: null, atlasFeatures: []});


### PR DESCRIPTION
Prevents certain print layouts from being displayed in the layout list of the print dialog.

Several print layouts are defined for a QWC theme. Some of them shouldn't be displayed in the layout list of the print dialog, but are used to print an info portfolio site (special reports created with a custom service).
Therefore, I can't exclude these print layouts in QGIS.

So I defined a prefix for print layout names. All layouts starting with these prefix are not displayed in the print dialog.
The prefix is ​​specified in the config.json file. I also specified a sort order and a default layout:

Added plugin config variables:
1. hidePrintlayoutPrefix: All layouts with this prefix will not be displayed in the print layoutlist
2. sortPrintlayouts: Alphabetical order for print layouts: asc or desc
3. defaultPrintlayout: The default layout to display first

config.json (example):
{
  "name": "Print",
  "cfg":  #{
    …
    "hidePrintlayoutPrefix": "_hide",
    "sortPrintlayouts": "desc",
    "defaultPrintlayout": "A4 - Hochformat"
  }
}