### PR TITLE
don't assume every export format has a specific configuration

### DIFF
--- a/plugins/MapExport.jsx
+++ b/plugins/MapExport.jsx
@@ -234,7 +234,7 @@ class MapExport extends React.Component {
                                     </td>
                                 </tr>
                             ) : null}
-                            {(formatConfiguration.projections || []).length > 1 ? (
+                            {(formatConfiguration?.projections || []).length > 1 ? (
                                 <tr>
                                     <td>{LocaleUtils.tr("mapexport.projection")}</td>
                                     <td>


### PR DESCRIPTION
This causes "TypeError: Cannot read properties of undefined (reading 'projections')" if there is no formatConfiguration.