### PR TITLE
Add missing layer parameter

### DIFF
--- a/plugins/MapTip.jsx
+++ b/plugins/MapTip.jsx
@@ -129,7 +129,7 @@ class MapTip extends React.Component {
             const request = IdentifyUtils.buildRequest(layer, queryLayers.join(","), this.state.mousePos.coordinate, this.props.map, options);
             IdentifyUtils.sendRequest(request, (response) => {
                 if (this.reqId === reqId) {
-                    const result = IdentifyUtils.parseXmlResponse(response || "", this.props.map.projection);
+                    const result = IdentifyUtils.parseXmlResponse(response || "", this.props.map.projection, layer);
                     const mapTips = [];
                     const features = [];
                     for (const sublayer of request.params.layers.split(",")) {

--- a/plugins/TimeManager.jsx
+++ b/plugins/TimeManager.jsx
@@ -668,7 +668,7 @@ class TimeManager extends React.Component {
             const request = IdentifyUtils.buildFilterRequest(layer, queryLayers, filterGeom, this.props.map, options);
             IdentifyUtils.sendRequest(request, (response) => {
                 if (this.state.timeFeatures && this.state.timeFeatures.reqUUID === reqUUID && response) {
-                    const layerFeatures = IdentifyUtils.parseXmlResponse(response, this.props.map.projection);
+                    const layerFeatures = IdentifyUtils.parseXmlResponse(response, this.props.map.projection, layer);
                     this.setState((state) => ({timeFeatures: {
                         features: {
                             ...state.timeFeatures.features,

--- a/plugins/ValueTool.jsx
+++ b/plugins/ValueTool.jsx
@@ -318,7 +318,7 @@ class ValueTool extends React.Component {
             const request = IdentifyUtils.buildRequest(layer, queryLayers.join(","), coordinate, this.props.map, options);
             IdentifyUtils.sendRequest(request, (response) => {
                 if (this.reqId === reqId) {
-                    const result = IdentifyUtils.parseXmlResponse(response || "", this.props.map.projection);
+                    const result = IdentifyUtils.parseXmlResponse(response || "", this.props.map.projection, layer);
                     this.setState(state => ({
                         values: {
                             ...state.values,

--- a/plugins/map/SnapSupport.jsx
+++ b/plugins/map/SnapSupport.jsx
@@ -106,7 +106,7 @@ class SnapSupport extends React.Component {
 
         const request = IdentifyUtils.buildRequest(layers, queryLayers, this.state.mousePos.coordinate, this.props.mapObj, options);
         axios.get(request.url, {params: request.params}).then(response => {
-            const results = IdentifyUtils.parseXmlResponse(response.data, this.props.mapObj.projection);
+            const results = IdentifyUtils.parseXmlResponse(response.data, this.props.mapObj.projection, layers);
             const features = [];
             results.forEach(result => {
                 for (const feature of result) {

--- a/plugins/map/SnappingSupport.jsx
+++ b/plugins/map/SnappingSupport.jsx
@@ -262,7 +262,7 @@ class SnappingSupport extends React.Component {
                 return;
             }
             if (response) {
-                const result = IdentifyUtils.parseXmlResponse(response, this.props.mapObj.projection);
+                const result = IdentifyUtils.parseXmlResponse(response, this.props.mapObj.projection, themeLayer);
                 const features = Object.values(result).reduce((res, cur) => [...res, ...cur], []);
                 const format = new ol.format.GeoJSON();
                 const olFeatures = format.readFeatures({


### PR DESCRIPTION
Fix Issue https://github.com/qgis/qwc2/issues/449

I am unsure about SnapSupport.jsx. The layers parameter is written here as a plural and is also used in the IdentifyUtils.buildRequest function above.  However, the IdentifyUtils.buildRequest function seems to expect a single layer.