### PR TITLE
Fix elevation when no result is found

### DIFF
--- a/plugins/MapInfoTooltip.jsx
+++ b/plugins/MapInfoTooltip.jsx
@@ -128,7 +128,7 @@ class MapInfoTooltip extends React.Component {
             ]);
         });
 
-        if (this.state.elevation) {
+        if (this.state.elevation !== undefined && this.state.elevation !== null) {
             let elevs = this.state.elevation.list;
             if (!elevs) {
                 elevs = [{elevation: this.state.elevation, dataset: null}];

--- a/utils/ElevationInterface.js
+++ b/utils/ElevationInterface.js
@@ -32,7 +32,7 @@ const ElevationInterface = {
                 return;
             }
             axios.get(serviceUrl + '/getelevation', {params: {pos: pos.join(","), crs}}).then(response => {
-                resolve(response.data.elevation || { list: response.data.elevation_list });
+                resolve(response.data.elevation ?? { list: response.data.elevation_list });
             }).catch((e) => {
                 reject(String(e));
             });


### PR DESCRIPTION
Hi,

This PR fixes an app crash when no elevation result is found when calling MapInfoTooltip plugin.

Value 0 is returned by qwc-elevation-service when no result is found in dataset but it was not handled well by the app with `||` operator. `??` is more appropriate here. And we need to check elevation state is not undefined or null instead of truthy.

Thanks