### PR TITLE
webpack: copy resources to build directory

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,7 +65,8 @@ module.exports = (env, argv) => {
             }),
             new CopyWebpackPlugin({
                 patterns: [
-                    { from: 'static' }
+                    { from: 'static' },
+                    { from: 'resources' }
                 ]
             })
         ],


### PR DESCRIPTION
Hi

I tried to build custom app with latest npm qwc2 package as dependency but it seems that `resources` is missing (for View3D plugin).

This PR aims to resolve this issue. I am not really familiar with webpack but I tried this with a local dependency and it should be enough.

PS: could you please release a new 2025.09.23.1 version on master branch too if it is merged ?

Thanks