### PR TITLE
Extract coordinates from getResultGeometry response for routing compatibility

### DIFF
--- a/components/widgets/SearchWidget.jsx
+++ b/components/widgets/SearchWidget.jsx
@@ -170,9 +170,9 @@ export default class SearchWidget extends React.Component {
                 this.props.resultSelected({
                     ...item,
                     feature: response ? VectorLayerUtils.reprojectFeature(response.feature, response.crs, item.crs) : null,
-                    x: response && response.center[0] !== undefined ? response.center[0] : null,
-                    y: response && response.center[1] !== undefined ? response.center[1] : null,
-                    crs: response && response.crs !== undefined ? response.crs : null
+                    x: item.x ?? (response?.center?.[0]),
+                    y: item.y ?? (response?.center?.[1]),
+                    crs: item.crs ?? response?.crs
                 });
             });
         } else {

--- a/components/widgets/SearchWidget.jsx
+++ b/components/widgets/SearchWidget.jsx
@@ -169,7 +169,10 @@ export default class SearchWidget extends React.Component {
             group.provider.getResultGeometry(item, (response) => {
                 this.props.resultSelected({
                     ...item,
-                    feature: response ? VectorLayerUtils.reprojectFeature(response.feature, response.crs, item.crs) : null
+                    feature: response ? VectorLayerUtils.reprojectFeature(response.feature, response.crs, item.crs) : null,
+                    x: response && response.center[0] !== undefined ? response.center[0] : null,
+                    y: response && response.center[1] !== undefined ? response.center[1] : null,
+                    crs: response && response.crs !== undefined ? response.crs : null
                 });
             });
         } else {


### PR DESCRIPTION
Hi!

I want to use a custom Search Provider in the Routing plugin, however, as I can only get the geometry of the result via getResultGeometry and I believe the Routing plugin expects the result to have x, y and crs in the result, I added this to extract those in SearchWidget.jsx.

Would this be a good approach?

Thanks for the feedback!