### PR TITLE
Add showHiddenFields option to AttributeTable plugin

### DIFF
--- a/components/AttributeTableWidget.jsx
+++ b/components/AttributeTableWidget.jsx
@@ -51,6 +51,8 @@ class AttributeTableWidget extends React.Component {
         setCurrentTaskBlocked: PropTypes.func,
         /** Whether to show a button to open the edit form for selected layer. Requires the Editing plugin to be enabled. */
         showEditFormButton: PropTypes.bool,
+        /** Whether to show hidden Fields. */
+        showHiddenFields: PropTypes.bool,
         /** Whether to show the layer selection menu. */
         showLayerSelection: PropTypes.bool,
         /** Whether to show the "Limit to extent" checkbox */
@@ -64,6 +66,7 @@ class AttributeTableWidget extends React.Component {
     static defaultProps = {
         zoomLevel: 1000,
         showEditFormButton: true,
+        showHiddenFields: true,
         showLayerSelection: true
     };
     static defaultState = {
@@ -154,13 +157,9 @@ class AttributeTableWidget extends React.Component {
         let table = null;
         let footbar = null;
         if (currentEditConfig && this.state.features) {
-            const fields = currentEditConfig.fields.reduce((res, field) => {
-                if (field.id !== "id") {
-                    res.push(field);
-                }
-                return res;
-            }, []);
-
+            const fields = currentEditConfig.fields
+                .filter(field => field.id !== "id")
+                .filter(field => this.props.showHiddenFields || field.constraints?.hidden !== true);
             const indexOffset = this.state.currentPage * this.state.pageSize;
             const features = this.state.filteredSortedFeatures.slice(indexOffset, indexOffset + this.state.pageSize);
             table = (

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -258,7 +258,8 @@ This plugin queries the dataset via the editing service specified by
 |----------|------|-------------|---------------|
 | allowAddForGeometryLayers | `bool` | Whether to allow adding records for datasets which have a geometry column. | `undefined` |
 | showEditFormButton | `bool` | Whether to show a button to open the edit form for selected layer. Requires the Editing plugin to be enabled. | `true` |
-| showLimitToExtent | `bool` | Whether to show the "Limit to extent" checkbox | `true` |
+| showHiddenFields | `bool` | Whether to show hidden Fields. | `true` |
+| showLimitToExtent | `bool` | Whether to show the "Limit to extent" checkbox | `undefined` |
 | zoomLevel | `number` | The zoom level for zooming to point features. | `1000` |
 
 Authentication<a name="authentication"></a>

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -259,7 +259,7 @@ This plugin queries the dataset via the editing service specified by
 | allowAddForGeometryLayers | `bool` | Whether to allow adding records for datasets which have a geometry column. | `undefined` |
 | showEditFormButton | `bool` | Whether to show a button to open the edit form for selected layer. Requires the Editing plugin to be enabled. | `true` |
 | showHiddenFields | `bool` | Whether to show hidden Fields. | `true` |
-| showLimitToExtent | `bool` | Whether to show the "Limit to extent" checkbox | `undefined` |
+| showLimitToExtent | `bool` | Whether to show the "Limit to extent" checkbox | `true` |
 | zoomLevel | `number` | The zoom level for zooming to point features. | `1000` |
 
 Authentication<a name="authentication"></a>

--- a/plugins/AttributeTable.jsx
+++ b/plugins/AttributeTable.jsx
@@ -38,6 +38,8 @@ class AttributeTable extends React.Component {
         setCurrentTask: PropTypes.func,
         /** Whether to show a button to open the edit form for selected layer. Requires the Editing plugin to be enabled. */
         showEditFormButton: PropTypes.bool,
+        /** Whether to show hidden fields. */
+        showHiddenFields: PropTypes.bool,
         /** Whether to show the "Limit to extent" checkbox */
         showLimitToExtent: PropTypes.bool,
         taskData: PropTypes.object,
@@ -47,6 +49,7 @@ class AttributeTable extends React.Component {
     static defaultProps = {
         zoomLevel: 1000,
         showEditFormButton: true,
+        showHiddenFields: true,
         showLimitToExtent: true
     };
     render() {
@@ -58,7 +61,8 @@ class AttributeTable extends React.Component {
                 <AttributeTableWidget allowAddForGeometryLayers={this.props.allowAddForGeometryLayers}
                     iface={this.props.iface} initialLayer={this.props.taskData?.layer}
                     role="body" showEditFormButton={this.props.showEditFormButton}
-                    showLimitToExtent={this.props.showLimitToExtent} zoomLevel={this.props.zoomLevel}
+                    showHiddenFields={this.props.showHiddenFields} showLimitToExtent={this.props.showLimitToExtent}
+                    zoomLevel={this.props.zoomLevel}
                 />
             </ResizeableWindow>
         );


### PR DESCRIPTION
This introduces a new option to control the visibility of hidden fields in the AttributeTable plugin.
By default, all fields are currently visible in the AttributeTable. 
When set to false, fields marked as hidden will no longer be displayed in the table.
The default is true to preserve existing behavior.