### PR TITLE
feat: add shapefile export

### DIFF
--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -33,6 +33,7 @@ import Spinner from './widgets/Spinner';
 
 import './style/IdentifyViewer.css';
 
+const EXCLUDE_PROPS = ['featurereport', 'displayfield', 'layername', 'layertitle', 'layerinfo', 'attribnames', 'clickPos', 'displayname', 'bbox'];
 
 const BuiltinExporters = [
     {
@@ -53,7 +54,7 @@ const BuiltinExporters = [
             const featureCollection = {
                 type: "FeatureCollection",
                 features: Object.values(json).flat().map(entry => {
-                    const feature = omit(entry, ['featurereport', 'displayfield', 'layername', 'layertitle', 'layerinfo', 'attribnames', 'clickPos', 'displayname', 'bbox']);
+                    const feature = omit(entry, EXCLUDE_PROPS);
                     if (feature.geometry) {
                         feature.crs = {
                             type: "name",
@@ -171,9 +172,7 @@ const BuiltinExporters = [
                 const promises = layers.map(([layerName, features]) => {
                     const geojson = {
                         type: "FeatureCollection",
-                        features: features.map(entry => {
-                            return omit(entry, ['featurereport', 'displayfield', 'layername', 'layertitle', 'layerinfo', 'attribnames', 'clickPos', 'displayname', 'bbox', 'crs']);
-                        })
+                        features: features.map(entry => omit(entry, EXCLUDE_PROPS))
                     };
                     const layerOptions = {...options, folder: layerName};
                     const crs = features[0]?.crs;

--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -16,7 +16,6 @@ import JSZip from 'jszip';
 import isEmpty from 'lodash.isempty';
 import omit from 'lodash.omit';
 import PropTypes from 'prop-types';
-import shpwrite from '@mapbox/shp-write';
 
 import {setActiveLayerInfo} from '../actions/layerinfo';
 import {LayerRole, addLayerFeatures, removeLayer, changeLayerProperty} from '../actions/layers';
@@ -158,39 +157,19 @@ const BuiltinExporters = [
         title: 'Shapefile',
         allowClipboard: false,
         export: (json, callback) => {
-            const layers = Object.entries(json);
-            const options = {
-                outputType: 'arraybuffer',
-                types: {
-                    point: 'points',
-                    polygon: 'polygons',
-                    polyline: 'lines'
-                }
-            };
-            if (layers.length === 1) {
-                const [layerName, features] = layers[0];
-                const geojson = {
-                    type: "FeatureCollection",
-                    features: features.map(entry => {
-                        return omit(entry, ['featurereport', 'displayfield', 'layername', 'layertitle', 'layerinfo', 'attribnames', 'clickPos', 'displayname', 'bbox', 'crs']);
-                    })
-                };
-                const layerOptions = {...options, folder: layerName};
-                const crs = features[0]?.crs;
-                if (crs) {
-                    const wkt = CoordinatesUtils.getWktFromCrs(crs);
-                    if (wkt) {
-                        layerOptions.prj = wkt;
+            import("@mapbox/shp-write").then(shpwriteMod => {
+                const shpwrite = shpwriteMod.default;
+                const layers = Object.entries(json);
+                const options = {
+                    outputType: 'arraybuffer',
+                    types: {
+                        point: 'points',
+                        polygon: 'polygons',
+                        polyline: 'lines'
                     }
-                }
-                shpwrite.zip(geojson, layerOptions).then((shpData) => {
-                    callback({
-                        data: shpData, type: "application/zip", filename: layerName + ".zip"
-                    });
-                });
-            } else {
-                const zip = new JSZip();
-                const promises = layers.map(([layerName, features]) => {
+                };
+                if (layers.length === 1) {
+                    const [layerName, features] = layers[0];
                     const geojson = {
                         type: "FeatureCollection",
                         features: features.map(entry => {
@@ -205,18 +184,41 @@ const BuiltinExporters = [
                             layerOptions.prj = wkt;
                         }
                     }
-                    return shpwrite.zip(geojson, layerOptions).then((shpData) => {
-                        zip.file(layerName + ".zip", shpData);
+                    shpwrite.zip(geojson, layerOptions).then((shpData) => {
+                        callback({
+                            data: shpData, type: "application/zip", filename: layerName + ".zip"
+                        });
                     });
-                });
-                Promise.all(promises).then(() => {
-                    return zip.generateAsync({type: "arraybuffer"});
-                }).then((result) => {
-                    callback({
-                        data: result, type: "application/zip", filename: "shapefiles.zip"
+                } else {
+                    const zip = new JSZip();
+                    const promises = layers.map(([layerName, features]) => {
+                        const geojson = {
+                            type: "FeatureCollection",
+                            features: features.map(entry => {
+                                return omit(entry, ['featurereport', 'displayfield', 'layername', 'layertitle', 'layerinfo', 'attribnames', 'clickPos', 'displayname', 'bbox', 'crs']);
+                            })
+                        };
+                        const layerOptions = {...options, folder: layerName};
+                        const crs = features[0]?.crs;
+                        if (crs) {
+                            const wkt = CoordinatesUtils.getWktFromCrs(crs);
+                            if (wkt) {
+                                layerOptions.prj = wkt;
+                            }
+                        }
+                        return shpwrite.zip(geojson, layerOptions).then((shpData) => {
+                            zip.file(layerName + ".zip", shpData);
+                        });
                     });
-                });
-            }
+                    Promise.all(promises).then(() => {
+                        return zip.generateAsync({type: "arraybuffer"});
+                    }).then((result) => {
+                        callback({
+                            data: result, type: "application/zip", filename: "shapefiles.zip"
+                        });
+                    });
+                }
+            });
         }
     }
 ];

--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
         "geospatial"
     ],
     "dependencies": {
+        "@esri/proj-codes": "^3.5.0",
         "@furkot/webfonts-generator": "^2.0.2",
         "@giro3d/giro3d": "^0.43.4",
         "@kayahr/text-encoding": "^2.0.0",
         "@loaders.gl/core": "^4.3.3",
         "@loaders.gl/shapefile": "^4.3.3",
         "@loaders.gl/zip": "^4.3.3",
+        "@mapbox/shp-write": "^0.4.3",
         "@panoramax/web-viewer": "^4.0.1",
         "@reduxjs/toolkit": "^2.4.0",
         "@turf/buffer": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
         "geospatial"
     ],
     "dependencies": {
-        "@esri/proj-codes": "^3.5.0",
         "@furkot/webfonts-generator": "^2.0.2",
         "@giro3d/giro3d": "^0.43.4",
         "@kayahr/text-encoding": "^2.0.0",

--- a/static/config.json
+++ b/static/config.json
@@ -54,27 +54,32 @@
     {
       "code": "EPSG:32632",
       "proj": "+proj=utm +zone=32 +datum=WGS84 +units=m +no_defs",
-      "label": "WGS 84 / UTM zone 32N"
+      "label": "WGS 84 / UTM zone 32N",
+      "esriWKt": "PROJCS[\"WGS_1984_UTM_Zone_32N\",GEOGCS[\"GCS_WGS_1984\",DATUM[\"D_WGS_1984\",SPHEROID[\"WGS_1984\",6378137.0,298.257223563]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"False_Easting\",500000.0],PARAMETER[\"False_Northing\",0.0],PARAMETER[\"Central_Meridian\",9.0],PARAMETER[\"Scale_Factor\",0.9996],PARAMETER[\"Latitude_Of_Origin\",0.0],UNIT[\"Meter\",1.0]]"
     },
     {
       "code": "EPSG:21781",
       "proj": "+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs",
-      "label": "CH1903 / LV03"
+      "label": "CH1903 / LV03",
+      "esriWkt": "PROJCS[\"CH1903_LV03\",GEOGCS[\"GCS_CH1903\",DATUM[\"D_CH1903\",SPHEROID[\"Bessel_1841\",6377397.155,299.1528128]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Hotine_Oblique_Mercator_Azimuth_Center\"],PARAMETER[\"False_Easting\",600000.0],PARAMETER[\"False_Northing\",200000.0],PARAMETER[\"Scale_Factor\",1.0],PARAMETER[\"Azimuth\",90.0],PARAMETER[\"Longitude_Of_Center\",7.43958333333333],PARAMETER[\"Latitude_Of_Center\",46.9524055555556],UNIT[\"Meter\",1.0]]"
     },
     {
       "code": "EPSG:2056",
       "proj": "+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs",
-      "label": "CH1903+ / LV95"
+      "label": "CH1903+ / LV95",
+      "esriWkt": "PROJCS[\"CH1903+_LV95\",GEOGCS[\"GCS_CH1903+\",DATUM[\"D_CH1903+\",SPHEROID[\"Bessel_1841\",6377397.155,299.1528128]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Hotine_Oblique_Mercator_Azimuth_Center\"],PARAMETER[\"False_Easting\",2600000.0],PARAMETER[\"False_Northing\",1200000.0],PARAMETER[\"Scale_Factor\",1.0],PARAMETER[\"Azimuth\",90.0],PARAMETER[\"Longitude_Of_Center\",7.43958333333333],PARAMETER[\"Latitude_Of_Center\",46.9524055555556],UNIT[\"Meter\",1.0]]"
     },
     {
       "code": "EPSG:25832",
       "proj": "+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
-      "label": "ETRS89 / UTM 32N"
+      "label": "ETRS89 / UTM 32N",
+      "esriWkt": "PROJCS[\"ETRS_1989_UTM_Zone_32N\",GEOGCS[\"GCS_ETRS_1989\",DATUM[\"D_ETRS_1989\",SPHEROID[\"GRS_1980\",6378137.0,298.257222101]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"False_Easting\",500000.0],PARAMETER[\"False_Northing\",0.0],PARAMETER[\"Central_Meridian\",9.0],PARAMETER[\"Scale_Factor\",0.9996],PARAMETER[\"Latitude_Of_Origin\",0.0],UNIT[\"Meter\",1.0]]"
     },
     {
       "code": "EPSG:31983",
       "proj": "+proj=utm +zone=23 +south +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
-      "label": "SIRGAS 2000 / UTM zone 23S"
+      "label": "SIRGAS 2000 / UTM zone 23S",
+      "esriWkt": "PROJCS[\"SIRGAS_2000_UTM_Zone_23S\",GEOGCS[\"GCS_SIRGAS_2000\",DATUM[\"D_SIRGAS_2000\",SPHEROID[\"GRS_1980\",6378137.0,298.257222101]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"False_Easting\",500000.0],PARAMETER[\"False_Northing\",10000000.0],PARAMETER[\"Central_Meridian\",-45.0],PARAMETER[\"Scale_Factor\",0.9996],PARAMETER[\"Latitude_Of_Origin\",0.0],UNIT[\"Meter\",1.0]]"
     }
   ],
   "plugins": {

--- a/utils/CoordinatesUtils.js
+++ b/utils/CoordinatesUtils.js
@@ -8,6 +8,7 @@
  */
 import ol from 'openlayers';
 import Proj4js from 'proj4';
+import projCodes from '@esri/proj-codes';
 
 import ConfigUtils from './ConfigUtils';
 import LocaleUtils from './LocaleUtils';
@@ -141,6 +142,16 @@ const CoordinatesUtils = {
     toOgcUrnCrs(crsStr) {
         const parts = crsStr.split(":");
         return "urn:ogc:def:crs:" + parts[0] + "::" + parts[1];
+    },
+    getWktFromCrs(crsStr) {
+        const epsgCode = crsStr.startsWith("EPSG:") ? crsStr : CoordinatesUtils.fromOgcUrnCrs(crsStr);
+        const wkid = parseInt(epsgCode.split(":")[1], 10);
+        const crs = projCodes.lookup(wkid);
+        if (crs && crs.wkt) {
+            return crs.wkt;
+        }
+        // If not found, return null (shapefile will use default)
+        return null;
     },
     getFormattedCoordinate(coo, srcCrs, dstCrs = null, options = {}) {
         const units = CoordinatesUtils.getUnits(dstCrs ?? srcCrs);

--- a/utils/CoordinatesUtils.js
+++ b/utils/CoordinatesUtils.js
@@ -147,7 +147,7 @@ const CoordinatesUtils = {
         const parts = crsStr.split(":");
         return "urn:ogc:def:crs:" + parts[0] + "::" + parts[1];
     },
-    getWktFromCrs(crsStr) {
+    getEsriWktFromCrs(crsStr) {
         const epsgCode = crsStr.startsWith("EPSG:") ? crsStr : CoordinatesUtils.fromOgcUrnCrs(crsStr);
 
         const projections = ConfigUtils.getConfigProp("projections") || [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -907,11 +907,6 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@esri/proj-codes@^3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@esri/proj-codes/-/proj-codes-3.5.0.tgz#d2f49d4ceeba86e07e77cbe875b78920fadc5f6b"
-  integrity sha512-EAS0mD6bBjx940IZ9RAfmrUqpcolL//dpgNR4eTWOvpPAdt2wHXuBGLQcegfItMUjMnKrEUpQBwFxRrRCNExPw==
-
 "@fontsource/atkinson-hyperlegible-next@^5.2.2":
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/@fontsource/atkinson-hyperlegible-next/-/atkinson-hyperlegible-next-5.2.3.tgz#c41fc6f2fff26b0669a44b954379bd1aa552113a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -907,6 +907,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
+"@esri/proj-codes@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@esri/proj-codes/-/proj-codes-3.5.0.tgz#d2f49d4ceeba86e07e77cbe875b78920fadc5f6b"
+  integrity sha512-EAS0mD6bBjx940IZ9RAfmrUqpcolL//dpgNR4eTWOvpPAdt2wHXuBGLQcegfItMUjMnKrEUpQBwFxRrRCNExPw==
+
 "@fontsource/atkinson-hyperlegible-next@^5.2.2":
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/@fontsource/atkinson-hyperlegible-next/-/atkinson-hyperlegible-next-5.2.3.tgz#c41fc6f2fff26b0669a44b954379bd1aa552113a"
@@ -1190,6 +1195,15 @@
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
   integrity sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==
+
+"@mapbox/shp-write@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@mapbox/shp-write/-/shp-write-0.4.3.tgz#74a47d4e6c44b327cc2cdb8f5bcd673c97bdd390"
+  integrity sha512-mkKIHgtnytyP+cXfk+joYeWwk+SODZ7COQusTcO1rZQVUn68MjzW2F74XMsNIusabnwj5aoKNI8B3mYq9KZ9AQ==
+  dependencies:
+    dbf "0.2.0"
+    file-saver "2.0.5"
+    jszip "^3.10.1"
 
 "@mapbox/tiny-sdf@^2.0.6":
   version "2.0.6"
@@ -2860,6 +2874,13 @@ dayjs@^1.11.13:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
   integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
+dbf@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/dbf/-/dbf-0.2.0.tgz#5b27a9c111f33ce255527010480a6291489fe87f"
+  integrity sha512-JMeGCJzFcVGsfnkIuqrnuiSkJpTu6c4AKJg3LXDnfW7zU/2PSIue3KG4fz9c+/mmlDzT+rVCwyEHzzhxzrzPiA==
+  dependencies:
+    jdataview "~2.5.0"
+
 debug@2.6.9, debug@^2.1.3, debug@^2.6.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -3583,7 +3604,7 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-file-saver@^2.0.5:
+file-saver@2.0.5, file-saver@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
   integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
@@ -4606,6 +4627,11 @@ iterator.prototype@^1.1.4:
     get-proto "^1.0.0"
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
+
+jdataview@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/jdataview/-/jdataview-2.5.0.tgz#3081b3fea651f9317ec6bd4feb2ddc98aa41d595"
+  integrity sha512-ZJop3D5nyDcWPBPv4NPnhCvx3HgQNsCXMfw8gpNKY16BobgxmVF+kJ08aHuqk6bJQVeL2mkf6nDCcZPMompalw==
 
 jest-worker@^27.4.5:
   version "27.5.1"


### PR DESCRIPTION
Adds a new Esri Shapefile export option to the IdentifyViewer component.

Changes:
* new CoordinateUtils.getWktFromCrs() method to convert EPSG codes to WKT
* new shapefile exporter in IdentifyViewer.jsx with single/multi-layer support (based on existing CSV and GeoJSON export structure)
* add @mapbox/shp-write dependency for shapefile generation
* add @esri/proj-codes for WKT/CRS conversion

I'm a bit concerned about the @esri/proj-codes dependency, as the package is  ~16 MB in size.

An alternative would be to maintain a simple lookup table with frequently used ESPGs (4326, 3857, etc.) and the option to add your own via JSON.