### PR TITLE
fix styling in RedliningBufferSupport

### DIFF
--- a/plugins/redlining/RedliningBufferSupport.jsx
+++ b/plugins/redlining/RedliningBufferSupport.jsx
@@ -65,7 +65,7 @@ class RedliningBufferSupport extends React.Component {
         }
         return (
             <div className="redlining-controlsbar">
-                <span>
+                <div className="redlining-control">
                     <span>{LocaleUtils.tr("redlining.bufferdistance")} &nbsp;</span>
                     <NumberInput max={99999} min={-99999} mobile
                         onChange={(nr) => this.setState({bufferDistance: nr})}
@@ -76,19 +76,19 @@ class RedliningBufferSupport extends React.Component {
                         <option value="kilometers">km</option>
                         <option value="miles">mi</option>
                     </select>
-                </span>
-                <span>
+                </div>
+                <div className="redlining-control">
                     <span>{LocaleUtils.tr("redlining.bufferlayer")}:&nbsp;</span>
                     <VectorLayerPicker
                         addLayer={this.props.addLayer} layers={layers}
                         onChange={layer => this.setState({bufferLayer: layer})}
                         value={this.state.bufferLayer.id} />
-                </span>
-                <span>
+                </div>
+                <div className="redlining-control">
                     <button className="button" disabled={!enabled} onClick={this.computeBuffer}>
                         {LocaleUtils.tr("redlining.buffercompute")}
                     </button>
-                </span>
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
before: 
<img width="527" height="129" alt="before" src="https://github.com/user-attachments/assets/014d697d-00ca-4479-b019-80062128cc95" />

after:
<img width="553" height="92" alt="after" src="https://github.com/user-attachments/assets/e71a6821-13e7-440f-80d0-28850d5bf4af" />
