### PR TITLE
VectorLayerUtils catch incorrect 3D geom in wktToGeoson

### DIFF
--- a/utils/VectorLayerUtils.js
+++ b/utils/VectorLayerUtils.js
@@ -392,10 +392,21 @@ const VectorLayerUtils = {
             const featureObj = new ol.format.GeoJSON().writeFeatureObject(feature);
             featureObj.id = id;
             return featureObj;
-        } catch (e) {
-            /* eslint-disable-next-line */
-            console.warn("Failed to parse geometry: " + wkt);
-            return null;
+        } catch (e1) {
+            const wkt2D = wkt.replace(/([0-9.+-]+)\s+([0-9.+-]+)\s+[0-9.+-]+/g, "$1 $2");
+            try {
+                const feature = new ol.format.WKT().readFeature(wkt2D, {
+                    dataProjection: srccrs,
+                    featureProjection: dstcrs
+                });
+                const featureObj = new ol.format.GeoJSON().writeFeatureObject(feature);
+                featureObj.id = id;
+                return featureObj;
+            } catch (e2) {
+                /* eslint-disable-next-line */
+                console.warn("Failed to parse geometry: " + wkt);
+                return null;
+            }
         }
     },
     geoJSONGeomToWkt(gj, precision = undefined) {


### PR DESCRIPTION
QGIS Server gives a incorrect geometry for the featureInfo request with option GeomCentroid=true, when the geometry is MultiPointZ. The response has no Z in the geometryname but 3D coordinates and is like:
 <Attribute name="geometry" value="POINT (2534760.0060000000000000 1154086.5760000000000000 0.0000000000000000)"
                type="derived" />
This results in a failure in creating feature from wkt here:
```
const feature = new ol.format.WKT().readFeature(wkt, {
                dataProjection: srccrs,
                featureProjection: dstcrs
            });
```
By removing the 3rd coordinate, the function will run. I tested with QGIS 3.40 and QGIS Server Image latest from qwc-qgis-server