### PR TITLE
EditingSupport fix undefined geomType in .replace()

### DIFF
--- a/plugins/map/EditingSupport.jsx
+++ b/plugins/map/EditingSupport.jsx
@@ -100,7 +100,7 @@ class EditingSupport extends React.Component {
     addDrawInteraction = () => {
         this.reset();
         this.createLayer();
-        const geomType = this.props.editContext.geomType?.replace(/Z$/, '') || '';
+        const geomType = this.props.editContext.geomType.replace(/Z$/, '');
         const drawInteraction = new ol.interaction.Draw({
             stopClick: true,
             type: geomType,


### PR DESCRIPTION
in some rare cases, the 
`const geomType = this.props.editContext.geomType?.replace(/Z$/, '')`
fails, when geomType is none or undefined. It is the case, when 
1. open edit dialog
2. select dras
3. close edit dialog without any action
The problem also occures, when editing a relational Value (nested) of a not saved parent feature. 