### PR TITLE
Fix tail marker of distance/bearing line measurement geometry

### DIFF
--- a/plugins/map/MeasurementSupport.jsx
+++ b/plugins/map/MeasurementSupport.jsx
@@ -172,10 +172,10 @@ class MeasurementSupport extends React.Component {
         const opts = {};
         if (this.props.measurement.geomType === 'LineString') {
             opts.headmarker = this.props.measurement.lineHeadMarker;
-            opts.tailmarker = this.props.measurement.lineHeadMarker;
+            opts.tailmarker = this.props.measurement.lineTailMarker;
         } else if (this.props.measurement.geomType === 'Bearing') {
             opts.headmarker = this.props.measurement.bearingHeadMarker;
-            opts.tailmarker = this.props.measurement.bearingHeadMarker;
+            opts.tailmarker = this.props.measurement.bearingTailMarker;
         }
         return [
             ...FeatureStyles.measureInteraction(feature, opts),


### PR DESCRIPTION
The tail marker configuration was never used for the distance/bearing line measurement geometry.