### PR TITLE
fix(IdentifyUtils): get layer title value when feature info response …

### DIFF
--- a/utils/IdentifyUtils.js
+++ b/utils/IdentifyUtils.js
@@ -291,7 +291,7 @@ const IdentifyUtils = {
                 layername = layerEl.attributes.name.value;
                 layertitle = LayerUtils.searchSubLayer(layer, 'name', layername)?.title ?? layername;
             } else {
-                layertitle = layerEl.attributes.name.value;
+                layertitle = layerEl.attributes.title.value;
                 layername = LayerUtils.searchSubLayer(layer, 'title', layertitle)?.name ?? layertitle;
             }
 


### PR DESCRIPTION
…returns it

Hi,

I am not sure about all the logic when getting layername, layer.name or layer.title when parsing XML response from GetFeatureInfo request.

But I think there was an issue when `featureInfoReturnsLayerName` is false as it does not display layer title instead of layer name.

Thanks