### PR TITLE
Fix GeoJSON feature export showing all zeros

### DIFF
--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -58,7 +58,7 @@ const BuiltinExporters = [
                     const feature = MiscUtils.objectOmit(entry, EXCLUDE_PROPS);
                     feature.properties = MiscUtils.objectOmit(feature.properties, EXCLUDE_ATTRS);
                     if (feature.geometry) {
-                        feature.geometry = VectorLayerUtils.reprojectGeometry(feature.geometry, entry, 'EPSG:4326');
+                        feature.geometry = VectorLayerUtils.reprojectGeometry(feature.geometry, entry.crs, 'EPSG:4326');
                     }
                     return feature;
                 })


### PR DESCRIPTION
When exporting the geometry to a geojson in the IdentifyViewer, all coordinates end up as 0 due to sending the entire `entry` object to `reprojectGeometry` instead of only `entry.crs`.