### PR TITLE
ThemesConfig: add defaultMapTips config

### DIFF
--- a/actions/theme.js
+++ b/actions/theme.js
@@ -178,6 +178,7 @@ export function setCurrentTheme(theme, themes, preserve = true, initialExtent = 
             printGrid: theme.printGrid || themes.defaultPrintGrid || undefined,
             searchProviders: theme.searchProviders || themes.defaultSearchProviders || undefined,
             backgroundLayers: theme.backgroundLayers || themes.defaultBackgroundLayers || [],
+            mapTips: theme.mapTips ?? themes.defaultMapTips ?? undefined,
             defaultDisplayCrs: theme.defaultDisplayCrs || themes.defaultDisplayCrs || undefined
         };
 

--- a/scripts/themesConfig.js
+++ b/scripts/themesConfig.js
@@ -609,6 +609,7 @@ function genThemes(themesConfig) {
             defaultPrintResolutions: config.defaultPrintResolutions,
             defaultPrintGrid: config.defaultPrintGrid,
             defaultSearchProviders: config.defaultSearchProviders,
+            defaultMapTips: config.defaultMapTips,
             defaultBackgroundLayers: config.defaultBackgroundLayers || [],
             externalLayers: config.themes.externalLayers || [],
             pluginData: config.themes.pluginData,

--- a/scripts/themesConfig.py
+++ b/scripts/themesConfig.py
@@ -625,6 +625,7 @@ def genThemes(themesConfig):
             "defaultPrintGrid": config["defaultPrintGrid"] if "defaultPrintGrid" in config else None,
             "defaultSearchProviders": config["defaultSearchProviders"] if "defaultSearchProviders" in config else None,
             "defaultBackgroundLayers": config["defaultBackgroundLayers"] if "defaultBackgroundLayers" in config else [],
+            "defaultMapTips": config["defaultMapTips"] if "defaultMapTips" in config else None,
             "pluginData": config["themes"]["pluginData"] if "pluginData" in config["themes"] else [],
             "themeInfoLinks": config["themes"]["themeInfoLinks"] if "themeInfoLinks" in config["themes"] else [],
             "externalLayers": config["themes"]["externalLayers"] if "externalLayers" in config["themes"] else [],


### PR DESCRIPTION
# Summary

This PR partially implements #571 . It adds a new parameter `defaultMapTips` so administrators can enable map tips for all the themes (similar to `defaultBackgroundLayers`).

# How to test this PR

With an instance with 2 themes configured in `mapViewerConfig.json`:

```diff
 {
   "resources": {
     "qwc2_themes": {
       "themes": {
         "title": "root",
         "items": [
           {
             "id": "foobar",
+            "mapTips": <themeMapTips>
           },
           {
             "id": "baz",
+             "mapTips": null
           }
         ],
         "defaultBackgroundLayers": [],
+        "defaultMapTips": <defaultMapTips>
       }
     }
   }
 }
```

| `defaultMapTips` value | `themeMapTips` value | Expected behavior for foobar theme | Expected behavior for baz theme |
|--|--|--|--|
| `undefined` or `null` | `true` | "Show layer map tips" checked  (unchanged) | "Show layer map tips" unchecked (unchanged) |
| `undefined` or `null` | `false` | "Show layer map tips" unchecked  (unchanged) | "Show layer map tips" unchecked (unchanged) |
| `undefined` or `null` | `undefined` or `null` | "Show layer map tips" unchecked  (unchanged) | "Show layer map tips" unchecked (unchanged) |
| `true` | `true` | "Show layer map tips" checked | "Show layer map tips" checked |
| `true` | `false` | "Show layer map tips" unchecked | "Show layer map tips" checked |
| `true` | `undefined` or `null` | "Show layer map tips" checked | "Show layer map tips" checked |
| `false` | `true` | "Show layer map tips" checked | "Show layer map tips" unchecked |
| `false` | `false` | "Show layer map tips" unchecked | "Show layer map tips" unchecked |
| `false` | `undefined` or `null` | "Show layer map tips" unchecked | "Show layer map tips" unchecked |
