### PR TITLE
Draft: QgisSearch: fix label when layer uses an expression as display name

### DIFF
--- a/utils/SearchProviders.js
+++ b/utils/SearchProviders.js
@@ -233,7 +233,7 @@ class QgisSearch {
             HEIGHT: 100,
             LAYERS: [],
             FILTER: [],
-            WITH_MAPTIP: false,
+            WITH_MAPTIP: true,
             WITH_GEOMETRY: true,
             feature_count: searchParams.cfgParams.featureCount || 100,
             info_format: 'text/xml'


### PR DESCRIPTION
Fixes #578 

I now correctly have the results:

<img width="531" height="220" alt="image" src="https://github.com/user-attachments/assets/20df6c49-62b8-4c85-a82d-4b43454ed00a" />
