### PR TITLE
FeatureSearch results: fix results being hidden if form is too long

### DIFF
--- a/plugins/style/FeatureSearch.css
+++ b/plugins/style/FeatureSearch.css
@@ -55,11 +55,6 @@ div.feature-search-bar > button > div.Spinner {
     margin-right: 1em;
 }
 
-div.feature-search-results {
-    flex: 1 1 auto;
-    overflow-y: auto;
-}
-
 div.feature-search-noresults {
     font-style: italic;
     padding: 0.25em;


### PR DESCRIPTION
When the FeatureSearch form is too long, the results get hidden, this PR fixes this. However, it changes the way the whole widget scrolls, making the form disappear when having many results:

* Form too long:

[Screencast from 2026-03-16 14-26-32.webm](https://github.com/user-attachments/assets/2d2254ad-f36b-4128-9df4-d108c7f6fcd4)

[Screencast from 2026-03-16 14-24-15.webm](https://github.com/user-attachments/assets/18e40da6-03f1-4f49-bcb2-23ea293dfed1)

* Many results:

[Screencast from 2026-03-16 14-26-52.webm](https://github.com/user-attachments/assets/de6c01dc-bd6d-428d-9f84-3476935b99fa)

[Screencast from 2026-03-16 14-24-34.webm](https://github.com/user-attachments/assets/aeb92c4c-9224-4356-8cbd-937f4d554ecc)


