### PR TITLE
feat: set startupTask through `task` URL parameter

### DIFF
--- a/actions/theme.js
+++ b/actions/theme.js
@@ -46,7 +46,7 @@ export function setThemeLayersList(theme) {
     };
 }
 
-export function finishThemeSetup(dispatch, theme, themes, layerConfigs, insertPos, permalinkLayers, externalLayerRestorer, visibleBgLayer, initialTheme) {
+export function finishThemeSetup(dispatch, theme, themes, layerConfigs, insertPos, permalinkLayers, externalLayerRestorer, visibleBgLayer, initialTheme, initialTask) {
     // Create layer
     const themeLayer = ThemeUtils.createThemeLayer(theme, themes);
     let layers = [themeLayer];
@@ -118,14 +118,15 @@ export function finishThemeSetup(dispatch, theme, themes, layerConfigs, insertPo
         type: SWITCHING_THEME,
         switching: false
     });
-    const task = theme.config?.startupTask;
+
+    const task = (initialTheme ? initialTask : null) || theme?.config?.startupTask || (initialTheme ? ConfigUtils.getConfigProp("startupTask") : null);
     if (task) {
         const mapClickAction = ConfigUtils.getPluginConfig(task.key).mapClickAction;
-        dispatch(setCurrentTask(task.key, task.mode, mapClickAction));
+        dispatch(setCurrentTask(task.key, task.mode, mapClickAction, task.data));
     }
 }
 
-export function setCurrentTheme(theme, themes, preserve = true, initialExtent = null, layerParams = null, visibleBgLayer = null, permalinkLayers = null, themeLayerRestorer = null, externalLayerRestorer = null) {
+export function setCurrentTheme(theme, themes, preserve = true, initialExtent = null, layerParams = null, visibleBgLayer = null, permalinkLayers = null, themeLayerRestorer = null, externalLayerRestorer = null, initialTask = null) {
     return (dispatch, getState) => {
         const curLayers = getState().layers?.flat || [];
         const mapCrs = theme.mapCrs || themes.defaultMapCrs || "EPSG:3857";
@@ -252,13 +253,13 @@ export function setCurrentTheme(theme, themes, preserve = true, initialExtent = 
                         dispatch(showNotification("missinglayers", LocaleUtils.tr("app.missinglayers", diff.join(", ")), NotificationType.WARN, true));
                     }
                 }
-                finishThemeSetup(dispatch, newTheme, themes, layerConfigs, insertPos, permalinkLayers, externalLayerRestorer, visibleBgLayer, initialTheme);
+                finishThemeSetup(dispatch, newTheme, themes, layerConfigs, insertPos, permalinkLayers, externalLayerRestorer, visibleBgLayer, initialTheme, initialTask);
             });
         } else {
             if (!isEmpty(missingThemeLayers)) {
                 dispatch(showNotification("missinglayers", LocaleUtils.tr("app.missinglayers", Object.keys(missingThemeLayers).join(", ")), NotificationType.WARN, true));
             }
-            finishThemeSetup(dispatch, theme, themes, layerConfigs, insertPos, permalinkLayers, externalLayerRestorer, visibleBgLayer, initialTheme);
+            finishThemeSetup(dispatch, theme, themes, layerConfigs, insertPos, permalinkLayers, externalLayerRestorer, visibleBgLayer, initialTheme, initialTask);
         }
     };
 }

--- a/actions/theme.js
+++ b/actions/theme.js
@@ -119,7 +119,7 @@ export function finishThemeSetup(dispatch, theme, themes, layerConfigs, insertPo
         switching: false
     });
 
-    const task = (initialTheme ? initialTask : null) || theme?.config?.startupTask || (initialTheme ? ConfigUtils.getConfigProp("startupTask") : null);
+    const task = initialTask || theme?.config?.startupTask || (initialTheme ? ConfigUtils.getConfigProp("startupTask") : null);
     if (task) {
         const mapClickAction = ConfigUtils.getPluginConfig(task.key).mapClickAction;
         dispatch(setCurrentTask(task.key, task.mode, mapClickAction, task.data));

--- a/components/StandardApp.jsx
+++ b/components/StandardApp.jsx
@@ -162,9 +162,8 @@ class AppContainerComponent extends React.Component {
             }
 
             const task = (params.task ? JSON.parse(decodeURIComponent(params.task)) : undefined)
-                || theme?.config?.startupTask
                 || ConfigUtils.getConfigProp("startupTask");
-            if (task) {
+            if (task && ((!params.task && !theme?.config?.startupTask) || (params.task && task !== theme?.config?.startupTask))) {
                 const mapClickAction = ConfigUtils.getPluginConfig(task.key).mapClickAction;
                 this.props.setCurrentTask(task.key, task.mode, mapClickAction, task.data);
             }

--- a/components/StandardApp.jsx
+++ b/components/StandardApp.jsx
@@ -156,16 +156,10 @@ class AppContainerComponent extends React.Component {
                 if (layerParams && ConfigUtils.getConfigProp("urlReverseLayerOrder")) {
                     layerParams.reverse();
                 }
-                this.props.setCurrentTheme(theme, themes, false, initialExtent, layerParams, params.bl ?? null, state.layers, this.props.appConfig.themeLayerRestorer, this.props.appConfig.externalLayerRestorer);
+                const initialTaskParam = (params.task ? JSON.parse(decodeURIComponent(params.task)) : null);
+                this.props.setCurrentTheme(theme, themes, false, initialExtent, layerParams, params.bl ?? null, state.layers, this.props.appConfig.themeLayerRestorer, this.props.appConfig.externalLayerRestorer, initialTaskParam);
             } else if (!ConfigUtils.havePlugin("Portal")) {
                 this.props.showNotification("missingdefaulttheme", LocaleUtils.tr("app.missingdefaulttheme", params.t), NotificationType.WARN, true);
-            }
-
-            const task = (params.task ? JSON.parse(decodeURIComponent(params.task)) : undefined)
-                || ConfigUtils.getConfigProp("startupTask");
-            if (task && ((!params.task && !theme?.config?.startupTask) || (params.task && task !== theme?.config?.startupTask))) {
-                const mapClickAction = ConfigUtils.getPluginConfig(task.key).mapClickAction;
-                this.props.setCurrentTask(task.key, task.mode, mapClickAction, task.data);
             }
         });
     };

--- a/components/StandardApp.jsx
+++ b/components/StandardApp.jsx
@@ -161,10 +161,12 @@ class AppContainerComponent extends React.Component {
                 this.props.showNotification("missingdefaulttheme", LocaleUtils.tr("app.missingdefaulttheme", params.t), NotificationType.WARN, true);
             }
 
-            const task = ConfigUtils.getConfigProp("startupTask");
-            if (task && !theme?.config?.startupTask) {
+            const task = (params.task ? JSON.parse(decodeURIComponent(params.task)) : undefined)
+                || theme?.config?.startupTask
+                || ConfigUtils.getConfigProp("startupTask");
+            if (task) {
                 const mapClickAction = ConfigUtils.getPluginConfig(task.key).mapClickAction;
-                this.props.setCurrentTask(task.key, task.mode, mapClickAction);
+                this.props.setCurrentTask(task.key, task.mode, mapClickAction, task.data);
             }
         });
     };

--- a/plugins/Editing.jsx
+++ b/plugins/Editing.jsx
@@ -135,6 +135,14 @@ class Editing extends React.Component {
             if (!LayerUtils.searchLayer(this.props.layers, 'wms_name', wmsName, 'name', layerName)) {
                 this.setState({selectedLayer: null});
             }
+        } else if (this.props.taskData && this.props.taskData !== prevProps.taskData) {
+            if (this.props.taskData.feature) {
+                const [wmsName, layerName] = this.props.taskData.layer.split("#");
+                const editConfig = this.props.editConfigs[wmsName][layerName];
+                this.props.iface.getFeatureById(editConfig, this.props.taskData.feature, this.props.map.projection, (feature) => {
+                    this.changeSelectedLayer(this.props.taskData.layer, feature || this.props.taskData.feature);
+                });
+            } else this.changeSelectedLayer(this.props.taskData.layer);
         }
         // If click point changed and in pick mode with a selected layer, trigger a pick
         const isCurrentContext = this.props.editContext.id === this.props.currentEditContext;

--- a/utils/PermaLinkUtils.js
+++ b/utils/PermaLinkUtils.js
@@ -71,7 +71,7 @@ export const UrlParams = {
         }
     },
     clear() {
-        const clearKeys = ['k', 't', 'l', 'bl', 'bk', 'c', 'hc', 'ic', 's', 'e', 'crs', 'st', 'sp', 'f', 'v', 'v3d', 'bl3d'];
+        const clearKeys = ['k', 't', 'l', 'bl', 'bk', 'c', 'hc', 'ic', 's', 'e', 'crs', 'st', 'sp', 'f', 'v', 'v3d', 'bl3d', 'task'];
         this.updateParams(clearKeys.reduce((res, key) => ({...res, [key]: undefined}), {}), true);
     },
     getFullUrl() {


### PR DESCRIPTION
Hi,

This PR allows to configure `startupTask` through URL parameters `stkey` and `stmode`. These parameters take precedence over per-theme configuration and global configuration parameter `startupTask`.

This could be used in external application which is interfacing QWC app with a configurable startup task.

I have a PR for documentation ready to push if this is accepted

Thanks for the review