### PR TITLE
add menuDisplayMode default value

### DIFF
--- a/components/AppMenu.jsx
+++ b/components/AppMenu.jsx
@@ -44,7 +44,8 @@ class AppMenu extends React.Component {
         showOnStartup: PropTypes.bool
     };
     static defaultProps = {
-        onMenuToggled: () => {}
+        onMenuToggled: () => {},
+        menuDisplayMode: "normal"
     };
     state = {
         menuVisible: false,


### PR DESCRIPTION
Hi!

Currently the Menu is always showing in the Portal plugin, that's because Portal does not pass menuDisplayMode to AppMenu, and AppMenu opens itself on mount when menuDisplayMode !== "normal", and this is always true as the prop is undefined. This should fix it.
