### PR TITLE
Fix/config json docs 583

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -756,7 +756,7 @@ or a custom elevation interface is exposed in `window.QWC2ElevationInterface` (s
 [ElevationInterface.js](https://github.com/qgis/qwc2/blob/master/utils/ElevationInterface.js)), the
 height at the picked position is also displayed.
 
-If `mapInfoService` in `config.json` points to a `qwc-mapinfo-service`, additional
+If `mapInfoServiceUrl` in `config.json` points to a `qwc-mapinfo-service`, additional
 custom information according to the `qwc-mapinfo-service` configuration is returned.
 
 You can pass additional plugin components to the `MapInfoTooltip` in `appConfig.js`:
@@ -776,7 +776,7 @@ class MapInfoTooltipPlugin extends React.Component {
 
 | Property | Type | Description | Default value |
 |----------|------|-------------|---------------|
-| elevationPrecision | `number` | The number of decimal places to display for elevation values. | `0` |
+| includeWGS84 | `bool` | Whether to display WGS84 coordinates in addition to map CRS coordinates. | `true` |
 | plugins | `array` | Additional plugin components for the map info tooltip. | `[]` |
 
 ## MapLegend<a name="maplegend"></a>

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -776,6 +776,7 @@ class MapInfoTooltipPlugin extends React.Component {
 
 | Property | Type | Description | Default value |
 |----------|------|-------------|---------------|
+| elevationPrecision | `number` | The number of decimal places to display for elevation values. | `0` |
 | includeWGS84 | `bool` | Whether to display WGS84 coordinates in addition to map CRS coordinates. | `true` |
 | plugins | `array` | Additional plugin components for the map info tooltip. | `[]` |
 

--- a/plugins/MapInfoTooltip.jsx
+++ b/plugins/MapInfoTooltip.jsx
@@ -36,7 +36,7 @@ import './style/MapInfoTooltip.css';
  * [ElevationInterface.js](https://github.com/qgis/qwc2/blob/master/utils/ElevationInterface.js)), the
  * height at the picked position is also displayed.
  *
- * If `mapInfoService` in `config.json` points to a `qwc-mapinfo-service`, additional
+ * If `mapInfoServiceUrl` in `config.json` points to a `qwc-mapinfo-service`, additional
  * custom information according to the `qwc-mapinfo-service` configuration is returned.
  *
  * You can pass additional plugin components to the `MapInfoTooltip` in `appConfig.js`:
@@ -93,7 +93,7 @@ class MapInfoTooltip extends React.Component {
                 getElevationInterface().getElevation(pos, crs).then(elevation => {
                     this.setState({elevation: elevation});
                 }).catch(() => {});
-                const mapInfoService = ConfigUtils.getConfigProp("mapInfoService");
+                const mapInfoService = ConfigUtils.getConfigProp("mapInfoServiceUrl") || ConfigUtils.getConfigProp("mapInfoService");
                 if (mapInfoService) {
                     axios.get(mapInfoService, {params: {pos: pos.join(","), crs}}).then(response => {
                         this.setState({extraInfo: response.data.results});

--- a/plugins/MapInfoTooltip.jsx
+++ b/plugins/MapInfoTooltip.jsx
@@ -60,6 +60,7 @@ class MapInfoTooltip extends React.Component {
         /** The number of decimal places to display for elevation values. */
         elevationPrecision: PropTypes.number,
         enabled: PropTypes.bool,
+        /** Whether to display WGS84 coordinates in addition to map CRS coordinates. */
         includeWGS84: PropTypes.bool,
         map: PropTypes.object,
         /** Additional plugin components for the map info tooltip. */

--- a/static/config.json
+++ b/static/config.json
@@ -6,6 +6,7 @@
   "permalinkServiceUrl": "http://localhost:8088/api/v1/permalink/",
   "elevationServiceUrl": "http://localhost:8088/elevation/",
   "featureReportService": "http://localhost:8088/api/v1/document/",
+  "documentServiceUrl": "http://localhost:8088/api/v1/document/",
   "authServiceUrl": "http://localhost:8088/api/v1/auth/",
   "routingServiceUrl": "https://valhalla1.openstreetmap.de",
   "availableLocales": {

--- a/static/config.json
+++ b/static/config.json
@@ -2,7 +2,7 @@
   "searchServiceUrl": "http://localhost:8088/api/v2/search/",
   "searchDataServiceUrl": "http://localhost:8088/api/v2/search/geom/",
   "editServiceUrl": "http://localhost:8088/api/v1/data/",
-  "mapInfoService": "http://localhost:8088/api/v1/mapinfo/",
+  "mapInfoServiceUrl": "http://localhost:8088/api/v1/mapinfo/",
   "permalinkServiceUrl": "http://localhost:8088/api/v1/permalink/",
   "elevationServiceUrl": "http://localhost:8088/elevation/",
   "featureReportService": "http://localhost:8088/api/v1/document/",


### PR DESCRIPTION
Fixes #583

- Renamed `mapInfoService` to `mapInfoServiceUrl` in `static/config.json`
- Renamed `mapInfoService` to `mapInfoServiceUrl` in `doc/plugins.md`
- Added missing `includeWGS84` parameter to MapInfoTooltip docs table
- Added `documentServiceUrl` to sample `static/config.json`