### PR TITLE
fix: bgLayer.params could be undefined

### DIFF
--- a/utils/ThemeUtils.js
+++ b/utils/ThemeUtils.js
@@ -64,7 +64,7 @@ const ThemeUtils = {
                     (externalLayers[key] = externalLayers[key] || []).push(params);
                     delete bgLayer.resource;
                 } else if (bgLayer.type === "wms") {
-                    bgLayer.version = bgLayer.params.VERSION || bgLayer.version || themes.defaultWMSVersion || "1.3.0";
+                    bgLayer.version = bgLayer.params?.VERSION || bgLayer.version || themes.defaultWMSVersion || "1.3.0";
                 } else if (bgLayer.type === "group") {
                     bgLayer.items = bgLayer.items.map(item => {
                         if (item.ref) {


### PR DESCRIPTION
Hi,

When adding a WMS background layer with Themes plugin in QWC admin, there are no "params" and "version" added to the configuration so `bgLayer.params` is undefined.

Thanks