### PR TITLE
LayerTree: add visibleOnStartup option

### DIFF
--- a/plugins/LayerTree.jsx
+++ b/plugins/LayerTree.jsx
@@ -83,8 +83,6 @@ class LayerTree extends React.Component {
         groupTogglesSublayers: PropTypes.bool,
         /** Whether to display the layer info button inside the layer settings menu rather than next to the layer title. */
         infoInSettings: PropTypes.bool,
-        /** Whether to open the LayerTree automatically when a theme is loaded. Can be set per-theme via the theme config. */
-        visibleOnStartup: PropTypes.bool,
         /** Default layer info window geometry with size, position and docking status. */
         layerInfoGeometry: PropTypes.shape({
             initialWidth: PropTypes.number,
@@ -134,6 +132,8 @@ class LayerTree extends React.Component {
         theme: PropTypes.object,
         toggleMapTips: PropTypes.func,
         transparencyIcon: PropTypes.bool,
+        /** Whether to open the LayerTree automatically when a theme is loaded. Can be set per-theme via the theme config. */
+        visibleOnStartup: PropTypes.bool,
         /** The initial width of the layertree, as a CSS width string. */
         width: PropTypes.string,
         zoomToExtent: PropTypes.func

--- a/plugins/LayerTree.jsx
+++ b/plugins/LayerTree.jsx
@@ -83,6 +83,8 @@ class LayerTree extends React.Component {
         groupTogglesSublayers: PropTypes.bool,
         /** Whether to display the layer info button inside the layer settings menu rather than next to the layer title. */
         infoInSettings: PropTypes.bool,
+        /** Whether to open the LayerTree automatically when a theme is loaded. Can be set per-theme via the theme config. */
+        visibleOnStartup: PropTypes.bool,
         /** Default layer info window geometry with size, position and docking status. */
         layerInfoGeometry: PropTypes.shape({
             initialWidth: PropTypes.number,
@@ -196,6 +198,12 @@ class LayerTree extends React.Component {
         }
         if (this.props.layers !== prevProps.layers) {
             this.setState({activePreset: LayerUtils.getActiveVisibilityPreset(this.props.layers, this.props.theme.visibilityPresets)});
+        }
+        if (this.props.theme !== prevProps.theme && this.props.theme?.id) {
+            const initiallyVisible = ConfigUtils.getConfigProp("visibleOnStartup", this.props.theme) ?? this.props.visibleOnStartup;
+            if (initiallyVisible) {
+                this.props.setCurrentTask("LayerTree");
+            }
         }
     }
     renderSubLayers = (layer, group, path, enabled, inMutuallyExclusiveGroup, usedGroupIds) => {


### PR DESCRIPTION
Adds a `visibleOnStartup` prop to the `LayerTree` plugin that automatically opens the layer tree when a theme is loaded. The value can be set via the plugin `cfg` or via `theme.config.visibleOnStartup` and follows the existing `appMenuVisibleOnStartup` naming convention.

```json
  { "name": "LayerTree", "cfg": { "visibleOnStartup": true } }
```

This frees the startupTask for other options and also does not collide with the Portal plugin.