### PR TITLE
fix(MapFilter): state may not be initialized when rendering predefined filters

### DIFF
--- a/plugins/MapFilter.jsx
+++ b/plugins/MapFilter.jsx
@@ -431,12 +431,12 @@ class MapFilter extends React.Component {
     };
     renderPredefinedFilters = () => {
         const predefinedFilters = this.collectPredefinedFilters(this.props.layers);
-        return Object.values(predefinedFilters).map(config => (
+        return Object.values(predefinedFilters).filter(filter => filter.id in this.state.filters).map(config => (
             <div className="map-filter-entry" key={config.id}>
                 <div className="map-filter-entry-titlebar">
                     <span className="map-filter-entry-title">{config.title ?? LocaleUtils.tr(config.titlemsgid)}</span>
                     <ToggleSwitch
-                        active={this.state.filters[config.id]?.active}
+                        active={this.state.filters[config.id].active}
                         onChange={(active) => this.toggleFilter(config.id, active)} />
                 </div>
                 <div className="map-filter-entry-body">


### PR DESCRIPTION
Hi,

When using MapFilter plugin as `startupTask` in a theme, state is not initialized before rendering predefined filters. This PR aims to fix this issue (`can't access property "values", n.state.filters[e.id] is undefined`).

This is testable with qwc_demo project.

Is it something that could be reported to `lts` branch ?

Thanks