### PR TITLE
fix(Help): reload content on componentDidUpdate to allow override per-theme help

### DIFF
--- a/plugins/Help.jsx
+++ b/plugins/Help.jsx
@@ -38,7 +38,10 @@ class Help extends React.Component {
         body: ''
     };
     componentDidMount() {
-        if (this.props.bodyContentsFragmentUrl) {
+        this.componentDidUpdate({});
+    }
+    componentDidUpdate(prevProps) {
+        if (this.props.bodyContentsFragmentUrl && this.props.bodyContentsFragmentUrl !== prevProps.bodyContentsFragmentUrl) {
             axios.get(this.props.bodyContentsFragmentUrl).then(response => {
                 this.setState({body: response.data.replace('$VERSION$', process.env.BuildDate)});
             }).catch(() => {});


### PR DESCRIPTION
Hi,

I would like to be able to override Help plugin content per-theme. 

```json
    "themes": {
        "items": [
          {
             "id": "theme1",
             ...
                "config": {
                    "plugins": {
                        "Help": {
                            "bodyContentsFragmentUrl": "assets/help_theme1.html"
                        }
                    },
                } 
          },
          {
             "id": "theme2",
             ...
                "config": {
                    "plugins": {
                        "Help": {
                            "bodyContentsFragmentUrl": "assets/help_theme2.html"
                        }
                    },
                } 
          }
        ]
    }
```

To do so, the plugin needs to get content when component is updated with a different content.

I am not sure that `componentDidMount` is still needed here.

Thanks for the review