### PR TITLE
fix(theme):  also get startupTask prop from per-theme mobile or desktop section

### DIFF
--- a/actions/theme.js
+++ b/actions/theme.js
@@ -119,7 +119,8 @@ export function finishThemeSetup(dispatch, theme, themes, layerConfigs, insertPo
         switching: false
     });
 
-    const task = initialTask || theme?.config?.startupTask || (initialTheme ? ConfigUtils.getConfigProp("startupTask") : null);
+    const section = ConfigUtils.isMobile() ? "mobile" : "desktop";
+    const task = initialTask || (theme?.config?.[section]?.startupTask ?? theme?.config?.startupTask) || (initialTheme ? ConfigUtils.getConfigProp("startupTask") : null);
     if (task) {
         const mapClickAction = ConfigUtils.getPluginConfig(task.key).mapClickAction;
         dispatch(setCurrentTask(task.key, task.mode, mapClickAction, task.data));


### PR DESCRIPTION
Hi,

I would like to override `startupTask` per-theme, but also only for "desktop" mode.

This PR allows it by getting prop using ConfigUtils.getConfigProp when there is no initialTask.

```js
getConfigProp(prop, theme, defval = undefined) {
        const section = config.isMobile ? "mobile" : "desktop";
        const themeProp = theme?.config?.[section]?.[prop] ?? theme?.config?.[prop];
        return themeProp ?? config[section]?.[prop] ?? config[prop] ?? defval;
}
```

Before, I was only checking for `theme?.config?.startupTask` for per-theme config, which is not enough for this use-case.

Thanks