### PR TITLE
MapExport: document that allowedFormats controls sort order and list supported mimetypes

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -739,7 +739,7 @@ Allows exporting a selected portion of the map to a variety of formats.
 
 | Property | Type | Description | Default value |
 |----------|------|-------------|---------------|
-| allowedFormats | `[string]` | Whitelist of allowed export format mimetypes. If empty, supported formats are listed. | `undefined` |
+| allowedFormats | `[string]` | Whitelist of allowed export format mimetypes. If empty, supported formats are listed. Formats are sorted according to this list, and the first entry becomes the default format. Supported mimetypes are: `image/jpeg`, `image/png`, `image/png; mode=16bit`, `image/png; mode=8bit`, `image/png; mode=1bit`, `image/geotiff`, `image/tiff`, `application/dxf`, `application/pdf`. | `undefined` |
 | allowedScales | `{[number], bool}` | List of scales at which to export the map. If empty, scale can be freely specified. If `false`, the map can only be exported at the current scale. | `undefined` |
 | defaultFormat | `string` | Default export format mimetype. If empty, first available format is used. | `undefined` |
 | defaultScaleFactor | `number` | The factor to apply to the map scale to determine the initial export map scale (if `allowedScales` is not `false`). | `1` |

--- a/plugins/MapExport.jsx
+++ b/plugins/MapExport.jsx
@@ -41,7 +41,7 @@ import "@kayahr/text-encoding/encodings/windows-1252";
  */
 class MapExport extends React.Component {
     static propTypes = {
-        /** Whitelist of allowed export format mimetypes. If empty, supported formats are listed. Formats are sorted according to this list, and the first entry becomes the default format. */
+        /** Whitelist of allowed export format mimetypes. If empty, supported formats are listed. Formats are sorted according to this list, and the first entry becomes the default format. Supported mimetypes are: `image/jpeg`, `image/png`, `image/png; mode=16bit`, `image/png; mode=8bit`, `image/png; mode=1bit`, `image/geotiff`, `image/tiff`, `application/dxf`, `application/pdf`. */
         allowedFormats: PropTypes.arrayOf(PropTypes.string),
         /** List of scales at which to export the map. If empty, scale can be freely specified. If `false`, the map can only be exported at the current scale. */
         allowedScales: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.number), PropTypes.bool]),

--- a/plugins/MapExport.jsx
+++ b/plugins/MapExport.jsx
@@ -41,7 +41,7 @@ import "@kayahr/text-encoding/encodings/windows-1252";
  */
 class MapExport extends React.Component {
     static propTypes = {
-        /** Whitelist of allowed export format mimetypes. If empty, supported formats are listed. */
+        /** Whitelist of allowed export format mimetypes. If empty, supported formats are listed. Formats are sorted according to this list, and the first entry becomes the default format. */
         allowedFormats: PropTypes.arrayOf(PropTypes.string),
         /** List of scales at which to export the map. If empty, scale can be freely specified. If `false`, the map can only be exported at the current scale. */
         allowedScales: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.number), PropTypes.bool]),


### PR DESCRIPTION
While checking whether MapExport supports ordering export formats like the Identify plugin's `enableExports`, I found that it already does. Updated the JSDoc comment and `doc/plugins.md` to make this explicit, including the list of supported mimetypes.