### PR TITLE
2D plugin functionality also in 3D plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -1331,6 +1331,10 @@ Map button for switching the background layer of the 3D map.
 
 Bottom bar of the 3D map, displaying coordinates, projection, etc.
 
+| Property | Type | Description | Default value |
+|----------|------|-------------|---------------|
+| displayCoordinates | `bool` | Whether to display the coordinates in the bottom bar. | `true` |
+
 ## Compare3D<a name="compare3d"></a>
 
 Split-screen and compare objects in the 3D map.
@@ -1364,6 +1368,8 @@ Layer and object tree for the 3D map
 |----------|------|-------------|---------------|
 | groupTogglesSublayers | `bool` | Whether toggling a group also toggles all sublayers. | `undefined` |
 | importedTilesBaseUrl | `string` | Base URL of imported tile sets. | `':/'` |
+| side | `string` | The side of the application on which to display the sidebar. | `'right'` |
+| width | `string` | The initial width of the layertree, as a CSS width string. | `'25em'` |
 
 ## MapCopyright3D<a name="mapcopyright3d"></a>
 
@@ -1414,7 +1420,7 @@ Compute sun exposure of terrain and objects within a selected area on the 3D map
 
 ## TopBar3D<a name="topbar3d"></a>
 
-Bottom bar of the 3D map, including the search bar, tool bar and menu.
+Top bar of the 3D map, including the search bar, tool bar and menu.
 
 | Property | Type | Description | Default value |
 |----------|------|-------------|---------------|

--- a/plugins/map3d/BottomBar3D.jsx
+++ b/plugins/map3d/BottomBar3D.jsx
@@ -11,10 +11,10 @@ import {connect} from 'react-redux';
 
 import PropTypes from 'prop-types';
 
-import {openExternalUrl, setBottombarHeight} from '../../actions/windows';
 import {ViewMode} from '../../actions/display';
-import CoordinatesUtils from '../../utils/CoordinatesUtils';
+import {openExternalUrl, setBottombarHeight} from '../../actions/windows';
 import ConfigUtils from '../../utils/ConfigUtils';
+import CoordinatesUtils from '../../utils/CoordinatesUtils';
 import LocaleUtils from '../../utils/LocaleUtils';
 
 import './style/BottomBar3D.css';
@@ -30,7 +30,8 @@ class BottomBar3D extends React.Component {
         fullscreen: PropTypes.bool,
         openExternalUrl: PropTypes.func,
         sceneContext: PropTypes.object,
-        setBottombarHeight: PropTypes.func
+        setBottombarHeight: PropTypes.func,
+        viewMode: PropTypes.number
     };
     static defaultProps = {
         displayCoordinates: true

--- a/plugins/map3d/BottomBar3D.jsx
+++ b/plugins/map3d/BottomBar3D.jsx
@@ -11,8 +11,9 @@ import {connect} from 'react-redux';
 
 import PropTypes from 'prop-types';
 
-import {setBottombarHeight} from '../../actions/windows';
+import {openExternalUrl, setBottombarHeight} from '../../actions/windows';
 import CoordinatesUtils from '../../utils/CoordinatesUtils';
+import LocaleUtils from '../../utils/LocaleUtils';
 
 import './style/BottomBar3D.css';
 
@@ -22,8 +23,36 @@ import './style/BottomBar3D.css';
  */
 class BottomBar3D extends React.Component {
     static propTypes = {
+        /** Additional bottombar links.`side` can be `left` or `right` (default). */
+        additionalBottomBarLinks: PropTypes.arrayOf(PropTypes.shape({
+            label: PropTypes.string,
+            labelMsgId: PropTypes.string,
+            side: PropTypes.string,
+            url: PropTypes.string,
+            urlTarget: PropTypes.string,
+            icon: PropTypes.string
+        })),
+        /** Whether to display the coordinates in the bottom bar. */
+        displayCoordinates: PropTypes.bool,
+        fullscreen: PropTypes.bool,
+        openExternalUrl: PropTypes.func,
         sceneContext: PropTypes.object,
-        setBottombarHeight: PropTypes.func
+        setBottombarHeight: PropTypes.func,
+        /** The URL of the terms label anchor. */
+        termsUrl: PropTypes.string,
+        /** Icon of the terms inline window. Relevant only when `termsUrlTarget` is `iframe`. */
+        termsUrlIcon: PropTypes.string,
+        /** The target where to open the terms URL. If `iframe`, it will be displayed in an inline window, otherwise in a new tab. You can also use the `:iframedialog:<dialogname>:<options>` syntax to set up the inline window. */
+        termsUrlTarget: PropTypes.string,
+        /** The URL of the viewer title label anchor. */
+        viewertitleUrl: PropTypes.string,
+        /** Icon of the viewer title inline window. Relevant only when `viewertitleUrl` is `iframe`. */
+        viewertitleUrlIcon: PropTypes.string,
+        /** The target where to open the viewer title URL. If `iframe`, it will be displayed in an inline window, otherwise in a new tab. You can also use the `:iframedialog:<dialogname>:<options>` syntax to set up the inline window. */
+        viewertitleUrlTarget: PropTypes.string
+    };
+    static defaultProps = {
+        displayCoordinates: true
     };
     state = {
         cursorPosition: null,
@@ -39,23 +68,64 @@ class BottomBar3D extends React.Component {
         clearTimeout(this.cursorPositionTimeout);
     }
     render() {
+        if (this.props.fullscreen) {
+            return null;
+        }
+        const leftBottomLinks = (this.props.additionalBottomBarLinks || []).filter(entry => entry.side === "left").map(this.renderLink);
+        const rightBottomLinks = (this.props.additionalBottomBarLinks || []).filter(entry => entry.side !== "left").map(this.renderLink); 
+        if (this.props.viewertitleUrl) {
+            const entry = {url: this.props.viewertitleUrl, urlTarget: this.props.viewertitleUrlTarget, label: LocaleUtils.tr("bottombar.viewertitle_label"), icon: this.props.viewertitleUrlIcon};
+            rightBottomLinks.push(this.renderLink(entry));
+        }
+        if (this.props.termsUrl) {
+            const entry = {url: this.props.termsUrl, urlTarget: this.props.termsUrlTarget, label: LocaleUtils.tr("bottombar.terms_label"), icon: this.props.termsUrlIcon};
+            rightBottomLinks.push(this.renderLink(entry));
+        }
+        let coordinates = null;
+        if (this.props.displayCoordinates) {
+            coordinates = (
+                <div className="controlgroup">
+                    <div className="map3d-bottombar-position">
+                        {(this.state.cursorPosition || []).map(x => x.toFixed(0)).join(" ")}
+                    </div>
+                    <div className="map3d-bottombar-projection">
+                        {this.props.sceneContext.mapCrs ? CoordinatesUtils.getAvailableCRS()[this.props.sceneContext.mapCrs].label : ""}
+                    </div>
+                    <div className="map3d-bottombar-spacer" />
+                </div>
+            );
+        }
         return (
             <div className="map3d-bottombar" ref={this.storeHeight}>
                 <div className="map3d-bottombar-progress">
                     <div className="map3d-bottombar-progressbar" style={{width: this.state.progress}} />
                     <div className="map3d-bottombar-progress-label">{this.state.progress}</div>
                 </div>
+                <span className="bottombar-links">
+                    {leftBottomLinks}
+                </span>
+                {coordinates}
                 <div className="map3d-bottombar-spacer" />
-                <div className="map3d-bottombar-position">
-                    {(this.state.cursorPosition || []).map(x => x.toFixed(0)).join(" ")}
-                </div>
-                <div className="map3d-bottombar-projection">
-                    {this.props.sceneContext.mapCrs ? CoordinatesUtils.getAvailableCRS()[this.props.sceneContext.mapCrs].label : ""}
-                </div>
-                <div className="map3d-bottombar-spacer" />
+                <span className="bottombar-links">
+                    {rightBottomLinks}
+                </span>
             </div>
         );
     }
+    renderLink = (entry) => {
+        return (
+            <a href={entry.url} key={entry.labelMsgId ?? entry.label} onClick={(ev) => this.openUrl(ev, entry.url, entry.urlTarget, entry.labelMsgId ? LocaleUtils.tr(entry.labelMsgId) : entry.label, entry.icon)}>
+                <span className="extra_label">{entry.labelMsgId ? LocaleUtils.tr(entry.labelMsgId) : entry.label}</span>
+            </a>
+        );
+    };
+    openUrl = (ev, url, target, title, icon) => {
+        if (target === "iframe") {
+            target = ":iframedialog:externallinkiframe";
+        }
+        this.props.openExternalUrl(url, target, {title, icon});
+        ev.preventDefault();
+    };
     scheduleGetCursorPosition = (ev) => {
         const rect = ev.currentTarget.getBoundingClientRect();
         const x = (ev.clientX - rect.left) / rect.width * 2 - 1;
@@ -77,6 +147,9 @@ class BottomBar3D extends React.Component {
     };
 }
 
-export default connect(() => ({}), {
-    setBottombarHeight: setBottombarHeight
+export default connect((state) => ({
+    fullscreen: state.display?.fullscreen,
+}), {
+    openExternalUrl: openExternalUrl,
+    setBottombarHeight: setBottombarHeight,
 })(BottomBar3D);

--- a/plugins/map3d/BottomBar3D.jsx
+++ b/plugins/map3d/BottomBar3D.jsx
@@ -81,17 +81,17 @@ class BottomBar3D extends React.Component {
             const entry = {url: this.props.termsUrl, urlTarget: this.props.termsUrlTarget, label: LocaleUtils.tr("bottombar.terms_label"), icon: this.props.termsUrlIcon};
             rightBottomLinks.push(this.renderLink(entry));
         }
-        let coordinates = null;
+        let position = null;
+        let projection = null;
         if (this.props.displayCoordinates) {
-            coordinates = (
-                <div className="controlgroup">
-                    <div className="map3d-bottombar-position">
-                        {(this.state.cursorPosition || []).map(x => x.toFixed(0)).join(" ")}
-                    </div>
-                    <div className="map3d-bottombar-projection">
-                        {this.props.sceneContext.mapCrs ? CoordinatesUtils.getAvailableCRS()[this.props.sceneContext.mapCrs].label : ""}
-                    </div>
-                    <div className="map3d-bottombar-spacer" />
+            position = (
+                <div className="map3d-bottombar-position">
+                    {(this.state.cursorPosition || []).map(x => x.toFixed(0)).join(" ")}
+                </div>
+            );
+            projection = (
+                <div className="map3d-bottombar-projection">
+                    {this.props.sceneContext.mapCrs ? CoordinatesUtils.getAvailableCRS()[this.props.sceneContext.mapCrs].label : ""}
                 </div>
             );
         }
@@ -104,7 +104,9 @@ class BottomBar3D extends React.Component {
                 <span className="bottombar-links">
                     {leftBottomLinks}
                 </span>
-                {coordinates}
+                <div className="map3d-bottombar-spacer" />
+                {position}
+                {projection}
                 <div className="map3d-bottombar-spacer" />
                 <span className="bottombar-links">
                     {rightBottomLinks}

--- a/plugins/map3d/BottomBar3D.jsx
+++ b/plugins/map3d/BottomBar3D.jsx
@@ -72,7 +72,7 @@ class BottomBar3D extends React.Component {
             return null;
         }
         const leftBottomLinks = (this.props.additionalBottomBarLinks || []).filter(entry => entry.side === "left").map(this.renderLink);
-        const rightBottomLinks = (this.props.additionalBottomBarLinks || []).filter(entry => entry.side !== "left").map(this.renderLink); 
+        const rightBottomLinks = (this.props.additionalBottomBarLinks || []).filter(entry => entry.side !== "left").map(this.renderLink);
         if (this.props.viewertitleUrl) {
             const entry = {url: this.props.viewertitleUrl, urlTarget: this.props.viewertitleUrlTarget, label: LocaleUtils.tr("bottombar.viewertitle_label"), icon: this.props.viewertitleUrlIcon};
             rightBottomLinks.push(this.renderLink(entry));
@@ -148,8 +148,8 @@ class BottomBar3D extends React.Component {
 }
 
 export default connect((state) => ({
-    fullscreen: state.display?.fullscreen,
+    fullscreen: state.display?.fullscreen
 }), {
     openExternalUrl: openExternalUrl,
-    setBottombarHeight: setBottombarHeight,
+    setBottombarHeight: setBottombarHeight
 })(BottomBar3D);

--- a/plugins/map3d/BottomBar3D.jsx
+++ b/plugins/map3d/BottomBar3D.jsx
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 
 import {openExternalUrl, setBottombarHeight} from '../../actions/windows';
 import CoordinatesUtils from '../../utils/CoordinatesUtils';
+import ConfigUtils from '../../utils/ConfigUtils';
 import LocaleUtils from '../../utils/LocaleUtils';
 
 import './style/BottomBar3D.css';
@@ -23,33 +24,12 @@ import './style/BottomBar3D.css';
  */
 class BottomBar3D extends React.Component {
     static propTypes = {
-        /** Additional bottombar links.`side` can be `left` or `right` (default). */
-        additionalBottomBarLinks: PropTypes.arrayOf(PropTypes.shape({
-            label: PropTypes.string,
-            labelMsgId: PropTypes.string,
-            side: PropTypes.string,
-            url: PropTypes.string,
-            urlTarget: PropTypes.string,
-            icon: PropTypes.string
-        })),
         /** Whether to display the coordinates in the bottom bar. */
         displayCoordinates: PropTypes.bool,
         fullscreen: PropTypes.bool,
         openExternalUrl: PropTypes.func,
         sceneContext: PropTypes.object,
-        setBottombarHeight: PropTypes.func,
-        /** The URL of the terms label anchor. */
-        termsUrl: PropTypes.string,
-        /** Icon of the terms inline window. Relevant only when `termsUrlTarget` is `iframe`. */
-        termsUrlIcon: PropTypes.string,
-        /** The target where to open the terms URL. If `iframe`, it will be displayed in an inline window, otherwise in a new tab. You can also use the `:iframedialog:<dialogname>:<options>` syntax to set up the inline window. */
-        termsUrlTarget: PropTypes.string,
-        /** The URL of the viewer title label anchor. */
-        viewertitleUrl: PropTypes.string,
-        /** Icon of the viewer title inline window. Relevant only when `viewertitleUrl` is `iframe`. */
-        viewertitleUrlIcon: PropTypes.string,
-        /** The target where to open the viewer title URL. If `iframe`, it will be displayed in an inline window, otherwise in a new tab. You can also use the `:iframedialog:<dialogname>:<options>` syntax to set up the inline window. */
-        viewertitleUrlTarget: PropTypes.string
+        setBottombarHeight: PropTypes.func
     };
     static defaultProps = {
         displayCoordinates: true
@@ -71,14 +51,15 @@ class BottomBar3D extends React.Component {
         if (this.props.fullscreen) {
             return null;
         }
-        const leftBottomLinks = (this.props.additionalBottomBarLinks || []).filter(entry => entry.side === "left").map(this.renderLink);
-        const rightBottomLinks = (this.props.additionalBottomBarLinks || []).filter(entry => entry.side !== "left").map(this.renderLink);
-        if (this.props.viewertitleUrl) {
-            const entry = {url: this.props.viewertitleUrl, urlTarget: this.props.viewertitleUrlTarget, label: LocaleUtils.tr("bottombar.viewertitle_label"), icon: this.props.viewertitleUrlIcon};
+        const bottomBarConfig = ConfigUtils.getPluginConfig("BottomBar")?.cfg ?? {};
+        const leftBottomLinks = (bottomBarConfig.additionalBottomBarLinks || []).filter(entry => entry.side === "left").map(this.renderLink);
+        const rightBottomLinks = (bottomBarConfig.additionalBottomBarLinks || []).filter(entry => entry.side !== "left").map(this.renderLink);
+        if (bottomBarConfig.viewertitleUrl) {
+            const entry = {url: bottomBarConfig.viewertitleUrl, urlTarget: bottomBarConfig.viewertitleUrlTarget, label: LocaleUtils.tr("bottombar.viewertitle_label"), icon: bottomBarConfig.viewertitleUrlIcon};
             rightBottomLinks.push(this.renderLink(entry));
         }
-        if (this.props.termsUrl) {
-            const entry = {url: this.props.termsUrl, urlTarget: this.props.termsUrlTarget, label: LocaleUtils.tr("bottombar.terms_label"), icon: this.props.termsUrlIcon};
+        if (bottomBarConfig.termsUrl) {
+            const entry = {url: bottomBarConfig.termsUrl, urlTarget: bottomBarConfig.termsUrlTarget, label: LocaleUtils.tr("bottombar.terms_label"), icon: bottomBarConfig.termsUrlIcon};
             rightBottomLinks.push(this.renderLink(entry));
         }
         let position = null;

--- a/plugins/map3d/BottomBar3D.jsx
+++ b/plugins/map3d/BottomBar3D.jsx
@@ -12,6 +12,7 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 
 import {openExternalUrl, setBottombarHeight} from '../../actions/windows';
+import {ViewMode} from '../../actions/display';
 import CoordinatesUtils from '../../utils/CoordinatesUtils';
 import ConfigUtils from '../../utils/ConfigUtils';
 import LocaleUtils from '../../utils/LocaleUtils';
@@ -82,16 +83,20 @@ class BottomBar3D extends React.Component {
                     <div className="map3d-bottombar-progressbar" style={{width: this.state.progress}} />
                     <div className="map3d-bottombar-progress-label">{this.state.progress}</div>
                 </div>
-                <span className="bottombar-links">
-                    {leftBottomLinks}
-                </span>
+                {this.props.viewMode === ViewMode._3DFullscreen ? (
+                    <span className="bottombar-links">
+                        {leftBottomLinks}
+                    </span>
+                ) : null}
                 <div className="map3d-bottombar-spacer" />
                 {position}
                 {projection}
                 <div className="map3d-bottombar-spacer" />
-                <span className="bottombar-links">
-                    {rightBottomLinks}
-                </span>
+                {this.props.viewMode === ViewMode._3DFullscreen ? (
+                    <span className="bottombar-links">
+                        {rightBottomLinks}
+                    </span>
+                ) : null}
             </div>
         );
     }
@@ -131,7 +136,8 @@ class BottomBar3D extends React.Component {
 }
 
 export default connect((state) => ({
-    fullscreen: state.display?.fullscreen
+    fullscreen: state.display?.fullscreen,
+    viewMode: state.display?.viewMode
 }), {
     openExternalUrl: openExternalUrl,
     setBottombarHeight: setBottombarHeight

--- a/plugins/map3d/LayerTree3D.jsx
+++ b/plugins/map3d/LayerTree3D.jsx
@@ -34,10 +34,16 @@ class LayerTree3D extends React.Component {
         /** Base URL of imported tile sets. */
         importedTilesBaseUrl: PropTypes.string,
         sceneContext: PropTypes.object,
-        setCurrentTask: PropTypes.func
+        setCurrentTask: PropTypes.func,
+        /** The side of the application on which to display the sidebar. */
+        side: PropTypes.string,
+        /** The initial width of the layertree, as a CSS width string. */
+        width: PropTypes.string
     };
     static defaultProps = {
-        importedTilesBaseUrl: ':/'
+        importedTilesBaseUrl: ':/',
+        side: 'right',
+        width: '25em'
     };
     state = {
         activestylemenu: null,
@@ -47,8 +53,9 @@ class LayerTree3D extends React.Component {
     render() {
         return (
             <SideBar icon="layers" id="LayerTree3D"
+                side={this.props.side}
                 title={LocaleUtils.tr("appmenu.items.LayerTree3D")}
-                width="20em"
+                width={this.state.sidebarwidth || this.props.width}
             >
                 {() => ({
                     body: this.renderBody()

--- a/plugins/map3d/TopBar3D.jsx
+++ b/plugins/map3d/TopBar3D.jsx
@@ -26,7 +26,7 @@ import ThemeUtils from '../../utils/ThemeUtils';
 
 
 /**
- * Bottom bar of the 3D map, including the search bar, tool bar and menu.
+ * Top bar of the 3D map, including the search bar, tool bar and menu.
  */
 class TopBar3D extends React.Component {
     static propTypes = {

--- a/plugins/map3d/style/BottomBar3D.css
+++ b/plugins/map3d/style/BottomBar3D.css
@@ -65,3 +65,9 @@ div.map3d-bottombar-projection {
     padding: 0.25em 0.5em;
     height: 2em;
 }
+
+div.map3d-bottombar span.bottombar-links > a:not(:first-child) {
+    border-left: 1px solid var(--panel-text-color);
+    margin-left: 0.5em;
+    padding-left: 0.5em;
+}

--- a/plugins/style/OverviewMap.css
+++ b/plugins/style/OverviewMap.css
@@ -2,6 +2,9 @@
 #BottomBar span.bottombar-links {
     margin-right: 3em;
 }
+div.map3d-bottombar span.bottombar-links {
+    margin-right: 3em;
+}
 
 div.overview-map {
     position: absolute;


### PR DESCRIPTION
This PR adds the following functions from the 2D bottom bar also to the 3D version in a first attempt:
- `additionalBottomBarLinks`
- `displayCoordinates`
- `termsUrl`
- `termsUrlIcon`
- `termsUrlTarget`
- `viewertitleUrl`
- `viewertitleUrlIcon`
- `viewertitleUrlTarget`

possible improvements could be:
- using `additionalBottomBarLinks`, `termsUrl*` and `viewertitleUrl*` from the BottomBar config instead of extra duplicated parameters (is that possible?)
- don't display `additionalBottomBarLinks`,  `termsUrl*` and `viewertitleUrl*` in splitscreen mode, as they are already visible in the 2D BottomBar, like it is done with the 2D menu and topbar items

Any ideas about the last two things? Thanks for review!