### PR TITLE
Disable scaling in MapExport when no frame is given

### DIFF
--- a/plugins/MapExport.jsx
+++ b/plugins/MapExport.jsx
@@ -276,7 +276,7 @@ class MapExport extends React.Component {
                 center={this.props.map.center} fixedFrame={frame} geometryChanged={this.geometryChanged} key="PrintSelection" scale={this.state.scale}
             />);
         } else {
-            return (<PrintSelection allowRotation={false} geometryChanged={this.geometryChanged} key="PrintSelection" />);
+            return (<PrintSelection allowRotation={false} allowScaling={false} geometryChanged={this.geometryChanged} key="PrintSelection" />);
         }
     };
     render() {


### PR DESCRIPTION
The missing parameter leads to weird glitches in the MapExport plugin, since 8c6a0c0ae8bde25c2afed3fb8be98679e37b53a2 