### PR TITLE
impr: add named substitution to the translation mecanism

### DIFF
--- a/utils/LocaleUtils.js
+++ b/utils/LocaleUtils.js
@@ -75,12 +75,16 @@ const LocaleUtils = {
             }
         });
     },
-    tr(key) {
+    tr(key, ...args) {
         const state = StandardApp.store.getState();
         const text = key in state.locale.messages ? (state.locale.messages[key] || state.locale.fallbackMessages[key] || key) : key;
 
-        const args = Array.prototype.slice.call(arguments, 1);
-        if (args.length > 0) {
+        if (args.length === 1 && args[0] && typeof args[0] === 'object' && !Array.isArray(args[0])) {
+            // Named substitution: {name} replaced from the dictionary
+            const dict = args[0];
+            return text.replace(/{(\w+)}/g, (match, name) => (name in dict ? dict[name] : match));
+        } else if (args.length > 0) {
+            // Positional substitution: {0}, {1}, ...
             return text.replace(/{(\d+)}/g, (match, number) => {
                 return typeof args[number] !== 'undefined' ? args[number] : match;
             });


### PR DESCRIPTION
This PR improves the translation mechanism and adds support for key based translations. 
It allows the user to use the LocaleUtils.tr() function with an object as second parameter, and to use named keys in the json translation file. The default mechanism is this available. 
For example, the translation : 
`"test": "this is a {foo} example. this is another {bar} example."`
Can be used with : 
`LocaleUtils.tr("test", {foo: "good", bar: "nice"})` 