### PR TITLE
Update updateTranslation.js regex to support kebab case

### DIFF
--- a/scripts/updateTranslations.js
+++ b/scripts/updateTranslations.js
@@ -72,7 +72,7 @@ const listDir = (dir, pattern) => {
 
 const updateTsConfig = (topdir, tsconfig, collectedMsgIds = null) => {
     const files = listDir(topdir, /^.*\.[jt]sx?$/);
-    const trRegEx = /LocaleUtils\.tr(?:msg)?\((['"])([A-Za-z0-9._]+)\1/g;
+    const trRegEx = /LocaleUtils\.tr(?:msg)?\((['"])([A-Za-z0-9._-]+)\1/g;
     const msgIds =  new Set();
     for (const file of files) {
         const data = fs.readFileSync(file).toString();


### PR DESCRIPTION
This PR adds the possibility for the user to use kebab-case for the translation keys, as well as already supported camelCase, snake_case or PascalCase. 