### PR TITLE
feat: params.featuresearch to exclude search provider from ObjectSearch

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -486,6 +486,11 @@ Displays a dialog with a search form for configured QGIS feature searches with o
 
 See [Configuring the QGIS feature search](../../topics/Search/#configuring-the-qgis-feature-search).
 
+A `qgis` entry in `theme.searchProviders` is listed here by default, including entries without an
+explicit `fields` configuration (which are rendered with a single default `TEXT` field). To configure
+a `qgis` provider which is only usable through the TopBar search (i.e. via `SearchBox`/`collectSearchProviders`)
+and should not appear in this dialog, set `params.featuresearch` to `false` on that provider entry.
+
 | Property | Type | Description | Default value |
 |----------|------|-------------|---------------|
 | enableExport | `{bool, array}` | Whether to enable the export functionality. Either `true|false` or a list of single allowed formats (builtin formats: `json`, `geojson`, `csv`, `csvzip`, `shapefile`, `xlsx`). If a list is provided, the export formats will be sorted according to that list, and the default format will be the first format of the list. | `true` |

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -486,11 +486,6 @@ Displays a dialog with a search form for configured QGIS feature searches with o
 
 See [Configuring the QGIS feature search](../../topics/Search/#configuring-the-qgis-feature-search).
 
-A `qgis` entry in `theme.searchProviders` is listed here by default, including entries without an
-explicit `fields` configuration (which are rendered with a single default `TEXT` field). To configure
-a `qgis` provider which is only usable through the TopBar search (i.e. via `SearchBox`/`collectSearchProviders`)
-and should not appear in this dialog, set `params.featuresearch` to `false` on that provider entry.
-
 | Property | Type | Description | Default value |
 |----------|------|-------------|---------------|
 | enableExport | `{bool, array}` | Whether to enable the export functionality. Either `true|false` or a list of single allowed formats (builtin formats: `json`, `geojson`, `csv`, `csvzip`, `shapefile`, `xlsx`). If a list is provided, the export formats will be sorted according to that list, and the default format will be the first format of the list. | `true` |

--- a/plugins/FeatureSearch.jsx
+++ b/plugins/FeatureSearch.jsx
@@ -33,11 +33,6 @@ import "./style/FeatureSearch.css";
  * Displays a dialog with a search form for configured QGIS feature searches with one or more input fields.
  *
  * See [Configuring the QGIS feature search](../../topics/Search/#configuring-the-qgis-feature-search).
- *
- * A `qgis` entry in `theme.searchProviders` is listed here by default, including entries without an
- * explicit `fields` configuration (which are rendered with a single default `TEXT` field). To configure
- * a `qgis` provider which is only usable through the TopBar search (i.e. via `SearchBox`/`collectSearchProviders`)
- * and should not appear in this dialog, set `params.featuresearch` to `false` on that provider entry.
  */
 class FeatureSearch extends React.Component {
     static propTypes = {

--- a/plugins/FeatureSearch.jsx
+++ b/plugins/FeatureSearch.jsx
@@ -33,6 +33,11 @@ import "./style/FeatureSearch.css";
  * Displays a dialog with a search form for configured QGIS feature searches with one or more input fields.
  *
  * See [Configuring the QGIS feature search](../../topics/Search/#configuring-the-qgis-feature-search).
+ *
+ * A `qgis` entry in `theme.searchProviders` is listed here by default, including entries without an
+ * explicit `fields` configuration (which are rendered with a single default `TEXT` field). To configure
+ * a `qgis` provider which is only usable through the TopBar search (i.e. via `SearchBox`/`collectSearchProviders`)
+ * and should not appear in this dialog, set `params.featuresearch` to `false` on that provider entry.
  */
 class FeatureSearch extends React.Component {
     static propTypes = {
@@ -63,7 +68,7 @@ class FeatureSearch extends React.Component {
             let defaultProvider = '';
             const providerGroups = {};
             const searchProviders = (this.props.theme?.searchProviders || []).reduce((res, entry) => {
-                if (entry.provider === "qgis" && entry.params) {
+                if (entry.provider === "qgis" && entry.params && entry.params.featuresearch !== false) {
                     const providerDef = {...entry};
                     if (!providerDef.params.fields) {
                         providerDef.params = {...providerDef.params};


### PR DESCRIPTION
Single-field qgis providers meant only for the TopBar quick search were also showing up in the ObjectSearch (FeatureSearch) sidebar, since it lists any qgis provider with params. This PR adds an opt-out flag, `params.featuresearch: false`, to exclude a provider from that dialog explicitly.