### PR TITLE
Toggle mode for LayerCatalog & SearchBox

### DIFF
--- a/components/SearchBox.jsx
+++ b/components/SearchBox.jsx
@@ -384,18 +384,18 @@ class SearchBox extends React.Component {
         const key = provider + ":" + group.id + ":" + result.id;
         const addThemes = ConfigUtils.getConfigProp("allowAddingOtherThemes", this.props.theme);
         let icon = null;
+        const toggleLayerGroup = (ev) => {
+            MiscUtils.killEvent(ev);
+            this.setState((state) => ({expandedLayerGroup: state.expandedLayerGroup === key ? null : key}));
+        };
         if (result.sublayers) {
-            const toggleLayerGroup = (ev) => {
-                MiscUtils.killEvent(ev);
-                this.setState((state) => ({expandedLayerGroup: state.expandedLayerGroup === key ? null : key}));
-            };
             icon = (<Icon icon={this.state.expandedLayerGroup === key ? "minus" : "plus"} onClick={ev => toggleLayerGroup(ev)} />);
         } else if (result.thumbnail) {
             icon = (<img className="searchbox-result-thumbnail" onError={(ev) => this.loadFallbackResultImage(ev, group.type)} src={result.thumbnail} />);
         }
         const selectResult = result.theme ? this.selectThemeResult : this.selectLayerResult;
         return [(
-            <div className="searchbox-result" key={key} onClick={() => selectResult(provider, group, result)} style={{borderLeft: `${level}em solid transparent`}}>
+            <div className="searchbox-result" key={key} onClick={ConfigUtils.getPluginConfig("LayerCatalog")?.cfg?.toggle && result.sublayers ? toggleLayerGroup : () => selectResult(provider, group, result)} style={{borderLeft: `${level}em solid transparent`}}>
                 {icon}
                 {result.theme ? (<Icon className="searchbox-result-openicon" icon="open" />) : null}
                 <span className="searchbox-result-label" dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(result.text).replace(/<br\s*\/>/ig, ' ')}} title={result.label ?? result.text} />

--- a/components/SearchBox.jsx
+++ b/components/SearchBox.jsx
@@ -395,7 +395,7 @@ class SearchBox extends React.Component {
         }
         const selectResult = result.theme ? this.selectThemeResult : this.selectLayerResult;
         return [(
-            <div className="searchbox-result" key={key} onClick={ConfigUtils.getPluginConfig("LayerCatalog")?.cfg?.toggle && result.sublayers ? toggleLayerGroup : () => selectResult(provider, group, result)} style={{borderLeft: `${level}em solid transparent`}}>
+            <div className="searchbox-result" key={key} onClick={ConfigUtils.getPluginConfig("LayerCatalog")?.cfg?.toggleGroupOnClick && result.sublayers ? toggleLayerGroup : () => selectResult(provider, group, result)} style={{borderLeft: `${level}em solid transparent`}}>
                 {icon}
                 {result.theme ? (<Icon className="searchbox-result-openicon" icon="open" />) : null}
                 <span className="searchbox-result-label" dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(result.text).replace(/<br\s*\/>/ig, ' ')}} title={result.label ?? result.text} />

--- a/components/widgets/LayerCatalogWidget.jsx
+++ b/components/widgets/LayerCatalogWidget.jsx
@@ -29,7 +29,8 @@ class LayerCatalogWidget extends React.PureComponent {
         pendingRequests: PropTypes.number,
         removeLayer: PropTypes.func,
         replacePlaceholderLayer: PropTypes.func,
-        showNotification: PropTypes.func
+        showNotification: PropTypes.func,
+        toggle: PropTypes.bool
     };
     state = {
         catalog: [],
@@ -88,7 +89,11 @@ class LayerCatalogWidget extends React.PureComponent {
                     this.checkAddServiceLayer(entry, true);
                 }
             } else {
-                this.checkAddServiceLayer(entry, false);
+                if (this.props.toggle && !isEmpty(entry.sublayers)) {
+                    this.toggleLayerListEntry(path);
+                } else {
+                    this.checkAddServiceLayer(entry, false);
+                }
             }
         } else {
             this.toggleLayerListEntry(path);

--- a/components/widgets/LayerCatalogWidget.jsx
+++ b/components/widgets/LayerCatalogWidget.jsx
@@ -30,7 +30,7 @@ class LayerCatalogWidget extends React.PureComponent {
         removeLayer: PropTypes.func,
         replacePlaceholderLayer: PropTypes.func,
         showNotification: PropTypes.func,
-        toggle: PropTypes.bool
+        toggleGroupOnClick: PropTypes.bool
     };
     state = {
         catalog: [],
@@ -89,7 +89,7 @@ class LayerCatalogWidget extends React.PureComponent {
                     this.checkAddServiceLayer(entry, true);
                 }
             } else {
-                if (this.props.toggle && !isEmpty(entry.sublayers)) {
+                if (this.props.toggleGroupOnClick && !isEmpty(entry.sublayers)) {
                     this.toggleLayerListEntry(path);
                 } else {
                     this.checkAddServiceLayer(entry, false);

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -673,6 +673,7 @@ Example:
 | geometry | `{`<br />`  initialWidth: number,`<br />`  initialHeight: number,`<br />`  initialX: number,`<br />`  initialY: number,`<br />`  initiallyDocked: bool,`<br />`  side: string,`<br />`}` | Default window geometry with size, position and docking status. Positive position values (including '0') are related to top (InitialY) and left (InitialX), negative values (including '-0') to bottom (InitialY) and right (InitialX).<br />- `initialWidth`: undefined<br />- `initialHeight`: undefined<br />- `initialX`: undefined<br />- `initialY`: undefined<br />- `initiallyDocked`: undefined<br />- `side`: undefined | `{`<br />`    initialWidth: 320,`<br />`    initialHeight: 320,`<br />`    initialX: 0,`<br />`    initialY: 0,`<br />`    initiallyDocked: false,`<br />`    side: 'left'`<br />`}` |
 | levelBasedIndentSize | `bool` | Whether to increase the indent size dynamically according to the current level (`true`) or keep the indent size constant (`false`). | `true` |
 | registerCatalogSearchProvider | `bool` | Whether to register a search provider which allows searching catalog layers through the global search field. | `true` |
+| toggleGroupOnClick | `bool` | Whether clicking the group name toggles the WMS group rather than loading the grouped layer. | `false` |
 
 ## LayerTree<a name="layertree"></a>
 

--- a/plugins/LayerCatalog.jsx
+++ b/plugins/LayerCatalog.jsx
@@ -95,7 +95,8 @@ class LayerCatalog extends React.Component {
         levelBasedIndentSize: PropTypes.bool,
         /** Whether to register a search provider which allows searching catalog layers through the global search field. */
         registerCatalogSearchProvider: PropTypes.bool,
-        setCurrentTask: PropTypes.func
+        setCurrentTask: PropTypes.func,
+        toggle: PropTypes.bool
     };
     static defaultProps = {
         geometry: {
@@ -155,7 +156,7 @@ class LayerCatalog extends React.Component {
                 onClose={this.onClose} title={LocaleUtils.tr("layercatalog.windowtitle")}
             >
                 <div className="layer-catalog">
-                    <LayerCatalogWidget catalog={this.state.catalog} levelBasedIndentSize={this.props.levelBasedIndentSize} pendingRequests={0} />
+                    <LayerCatalogWidget catalog={this.state.catalog} levelBasedIndentSize={this.props.levelBasedIndentSize} pendingRequests={0} toggle={this.props.toggle} />
                 </div>
             </ResizeableWindow>
         );

--- a/plugins/LayerCatalog.jsx
+++ b/plugins/LayerCatalog.jsx
@@ -96,7 +96,8 @@ class LayerCatalog extends React.Component {
         /** Whether to register a search provider which allows searching catalog layers through the global search field. */
         registerCatalogSearchProvider: PropTypes.bool,
         setCurrentTask: PropTypes.func,
-        toggle: PropTypes.bool
+        /** Whether clicking the group name toggles the WMS group rather than loading the grouped layer. */
+        toggleGroupOnClick: PropTypes.bool
     };
     static defaultProps = {
         geometry: {
@@ -108,7 +109,8 @@ class LayerCatalog extends React.Component {
             side: 'left'
         },
         levelBasedIndentSize: true,
-        registerCatalogSearchProvider: true
+        registerCatalogSearchProvider: true,
+        toggleGroupOnClick: false
     };
     state = {
         catalog: null,
@@ -156,7 +158,7 @@ class LayerCatalog extends React.Component {
                 onClose={this.onClose} title={LocaleUtils.tr("layercatalog.windowtitle")}
             >
                 <div className="layer-catalog">
-                    <LayerCatalogWidget catalog={this.state.catalog} levelBasedIndentSize={this.props.levelBasedIndentSize} pendingRequests={0} toggle={this.props.toggle} />
+                    <LayerCatalogWidget catalog={this.state.catalog} levelBasedIndentSize={this.props.levelBasedIndentSize} pendingRequests={0} toggleGroupOnClick={this.props.toggleGroupOnClick} />
                 </div>
             </ResizeableWindow>
         );


### PR DESCRIPTION
Hello @manisandro, 

I've made this PR regarding #665. 

This will allow the user to chose if he wants to load catalog wms without arborescence or toggle the menu instead. 

Using the optiong toggle = true in LayerCatalog configuration. 

I've modified the SearchBox behavior accordingly. 

Let me know if it's work for you or if I need to change anything 

PS : Sorry for the previous PR ! :grinning: 

Regards,
Clément. 