### PR TITLE
MapExport3D improvements

### DIFF
--- a/components/ExportSelection.jsx
+++ b/components/ExportSelection.jsx
@@ -39,24 +39,36 @@ export default class ExportSelection extends React.Component {
         }
         if (this.props.frameRatio !== prevProps.frameRatio) {
             this.setState(state => {
-                const maxWidth = this.exportContainer.offsetWidth;
-                const maxHeight = this.exportContainer.offsetHeight;
-                let newheight = this.props.frameRatio ? Math.round(state.width * this.props.frameRatio) : state.height;
-                let newwidth = state.width;
+                const containerWidth = this.exportContainer.offsetWidth;
+                const containerHeight = this.exportContainer.offsetHeight;
+                const maxWidth = 0.75 * containerWidth;
+                const maxHeight = 0.75 * containerHeight;
+                let newwidth;
+                let newheight;
                 if (this.props.frameRatio) {
-                    if (newwidth > maxWidth) {
+                    if (this.props.frameRatio >= 1) {
                         newwidth = maxWidth;
                         newheight = Math.round(newwidth * this.props.frameRatio);
-                    }
-                    if (newheight > maxHeight) {
+                        if (newheight > maxHeight) {
+                            newheight = maxHeight;
+                            newwidth = Math.round(newheight / this.props.frameRatio);
+                        }
+                    } else {
                         newheight = maxHeight;
                         newwidth = Math.round(newheight / this.props.frameRatio);
+                        if (newwidth > maxWidth) {
+                            newwidth = maxWidth;
+                            newheight = Math.round(newwidth * this.props.frameRatio);
+                        }
                     }
+                } else {
+                    newwidth = state.width;
+                    newheight = state.height;
                 }
                 return {
                     frameRatio: this.props.frameRatio,
-                    x: 0.5 * (maxWidth - newwidth),
-                    y: 0.5 * (maxHeight - newheight),
+                    x: 0.5 * (containerWidth - newwidth),
+                    y: 0.5 * (containerHeight - newheight),
                     width: newwidth,
                     height: newheight
                 };

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -1428,6 +1428,10 @@ Displays layer attributions in the bottom right corner of the 3D map.
 
 Export the 3D map image to raster formats.
 
+| Property | Type | Description | Default value |
+|----------|------|-------------|---------------|
+| formats | `[string]` | Export layout format mimetypes. Only the default values are supported. | `['image/jpeg', 'image/png', 'image/tiff', 'application/pdf']` |
+
 ## MapLight3D<a name="maplight3d"></a>
 
 Control the map illumination.

--- a/plugins/map3d/MapExport3D.jsx
+++ b/plugins/map3d/MapExport3D.jsx
@@ -308,14 +308,13 @@ class MapExport3D extends React.Component {
         }
 
         this.setState({exporting: true});
-        const {canvas, context} = this.takeScreenshot(exportScale, this.state.frame);
+        const {canvas, imageData} = this.takeScreenshot(exportScale, this.state.frame);
 
         if (this.state.selectedFormat === "application/pdf") {
             canvas.toBlob((blob) => {
                 blob.arrayBuffer().then(imgBuffer => this.exportToPdf(form, imgBuffer));
             }, "image/png");
         } else if (this.state.selectedFormat === "image/tiff") {
-            const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
             const blob = new Blob([utif.encodeImage(imageData.data, canvas.width, canvas.height)], { type: "image/tiff" });
             FileSaver.saveAs(blob, "export." + this.state.selectedFormat.replace(/.*\//, ''));
             this.setState({exporting: false});

--- a/plugins/map3d/MapExport3D.jsx
+++ b/plugins/map3d/MapExport3D.jsx
@@ -35,6 +35,8 @@ import '../style/MapExport.css';
 class MapExport3D extends React.Component {
     static propTypes = {
         bottombarHeight: PropTypes.number,
+        /** Export layout format mimetypes. Only the default values are supported. */
+        formats: PropTypes.arrayOf(PropTypes.string),
         hideAutopopulatedFields: PropTypes.bool,
         sceneContext: PropTypes.object,
         setCurrentTask: PropTypes.func,
@@ -52,6 +54,15 @@ class MapExport3D extends React.Component {
         exportScaleFactor: 100,
         exportDpi: 300
     };
+    static defaultProps = {
+        formats: ['image/jpeg', 'image/png', 'image/tiff', 'application/pdf']
+    };
+    static formatMap = {
+        "image/jpeg": "JPEG",
+        "image/png": "PNG",
+        "image/tiff": "TIFF",
+        "application/pdf": "PDF"
+    };
     state = MapExport3D.defaultState;
     onShow = () => {
         const rect = this.props.sceneContext.scene.domElement.getBoundingClientRect();
@@ -62,14 +73,15 @@ class MapExport3D extends React.Component {
             width: 0.75 * rect.width,
             height: 0.75 * rectHeight
         };
+        const selectedFormat = this.props.formats[0] || 'image/jpeg';
         if (!isEmpty(this.props.theme?.print)) {
             const layouts = this.props.theme.print.filter(l => l.map).sort((a, b) => {
                 return a.name.split('/').pop().localeCompare(b.name.split('/').pop(), undefined, {numeric: true});
             });
             const exportDpi = this.props.theme.printResolutions?.find(x => x === 300) ?? this.props.theme.printResolutions?.[0] ?? 300;
-            this.setState({layouts: layouts, exportDpi: exportDpi, frame: frame});
+            this.setState({layouts: layouts, exportDpi: exportDpi, frame: frame, selectedFormat: selectedFormat});
         } else {
-            this.setState({layouts: [], frame: frame});
+            this.setState({layouts: [], frame: frame, selectedFormat: selectedFormat});
         }
     };
     onHide = () => {
@@ -94,12 +106,12 @@ class MapExport3D extends React.Component {
         }));
     };
     renderBody = () => {
-        const formatMap = {
-            "image/jpeg": "JPEG",
-            "image/png": "PNG",
-            "image/tiff": "TIFF",
-            "application/pdf": "PDF"
-        };
+        const formatMap = this.props.formats.reduce((acc, format) => {
+            if (MapExport3D.formatMap[format]) {
+                acc[format] = MapExport3D.formatMap[format];
+            }
+            return acc;
+        }, {});
         const exportDisabled = this.state.exporting || this.state.width === 0 || (
             this.state.selectedFormat === "application/pdf" && !this.state.layout
         );


### PR DESCRIPTION
This PR improves the changes made related to https://github.com/qgis/qwc2/issues/677 a little bit more.

For PDF export the selection consider 75 % percent of the window width and height, and for landscape print templates, the selection is based on the width and not the height.

Furthermore, the export formats of the plugin could be set with a config parameter.