### PR TITLE
Fix defaultBackgroundLayers fallback for empty backgroundLayers

### DIFF
--- a/actions/theme.js
+++ b/actions/theme.js
@@ -181,7 +181,7 @@ export function setCurrentTheme(theme, themes, preserve = true, initialExtent = 
             printResolutions: theme.printResolutions ?? themes.defaultPrintResolutions,
             printGrid: theme.printGrid ?? themes.defaultPrintGrid,
             searchProviders: theme.searchProviders ?? themes.defaultSearchProviders,
-            backgroundLayers: theme.backgroundLayers ?? themes.defaultBackgroundLayers ?? [],
+            backgroundLayers: theme.backgroundLayers?.length ? theme.backgroundLayers : (themes.defaultBackgroundLayers ?? []),
             mapTips: theme.mapTips ?? themes.defaultMapTips,
             defaultDisplayCrs: theme.defaultDisplayCrs || themes.defaultDisplayCrs
         };


### PR DESCRIPTION
Empty backgroundLayers arrays prevent the defaultBackgroundLayers fallback and can be set by qwc-admin-gui or qwc-map-viewer: 
https://github.com/qwc-services/qwc-admin-gui/blob/master/src/plugins/themes/controllers/themes_controller.py#L741 
https://github.com/qwc-services/qwc-map-viewer/blob/master/src/qwc2_viewer.py#L1250

Since ?? only falls back for null or undefined, defaultBackgroundLayers was not used.