### PR TITLE
fix isochrone redlining layer

### DIFF
--- a/plugins/Routing.jsx
+++ b/plugins/Routing.jsx
@@ -935,7 +935,7 @@ class Routing extends React.Component {
             title: LocaleUtils.tr("routing.reachability"),
             type: 'vector'
         };
-        this.props.addLayerFeatures(layer, [this.collectIsochroneFeatures()]);
+        this.props.addLayerFeatures(layer, this.collectIsochroneFeatures());
         this.props.setCurrentTask("LayerTree");
     };
     onSortChange = (order, sortable, ev) => {


### PR DESCRIPTION
When exporting the isochrone (reachability) routing results as a redlining layer, a layer is created in the layer tree, but no data is visible on the map. This should resolve the issue.
