### PR TITLE
Redlining: convert HTML linebreaks to \n

### DIFF
--- a/plugins/redlining/RedliningFeatureLabelSupport.jsx
+++ b/plugins/redlining/RedliningFeatureLabelSupport.jsx
@@ -121,6 +121,7 @@ class RedliningFeatureLabelSupport extends React.Component {
         } else {
             text = String(text);
         }
+        text = text.replace(/<\/?br\s*\/?>/gi, '\n').replace(/&#10;/g, '\n');
         const center = cur.mapPos;
         let feature = (this.props.layers.find(l => l.id === this.props.redlining.layer)?.features || []).find(f => f.id === featureId);
         if (feature) {


### PR DESCRIPTION
QGIS Server encodes line breaks in multiline text fields values as `<br>` or `</br>` tags. The text rendering of OL just puts prints those literal tags. 

This PR replaces `<br>` and `</br>` occurences into `\n` characters for proper linebreaks.