### PR TITLE
Identify: export numeric-looking attribute values as numbers in XLSX export

### DIFF
--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -38,6 +38,13 @@ import ToggleSwitch from './widgets/ToggleSwitch';
 
 import './style/IdentifyViewer.css';
 
+function xlsxCellValue(value) {
+    if (typeof value === 'string' && value.trim() !== '' && String(Number(value)) === value.trim()) {
+        return Number(value);
+    }
+    return value;
+}
+
 const BuiltinExporters = [
     {
         id: 'json',
@@ -230,7 +237,7 @@ const BuiltinExporters = [
                         dataset[0].push("geometry");
                     }
                     features.forEach(feature => {
-                        const row = exportAttrs.map(attr => feature.properties[attr]);
+                        const row = exportAttrs.map(attr => xlsxCellValue(feature.properties[attr]));
                         if (feature.geometry) {
                             const geomWkt = VectorLayerUtils.geoJSONGeomToWkt(feature.geometry);
                             if (geomWkt.length < 32768) {

--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -38,13 +38,6 @@ import ToggleSwitch from './widgets/ToggleSwitch';
 
 import './style/IdentifyViewer.css';
 
-function xlsxCellValue(value) {
-    if (typeof value === 'string' && value.trim() !== '' && String(Number(value)) === value.trim()) {
-        return Number(value);
-    }
-    return value;
-}
-
 const BuiltinExporters = [
     {
         id: 'json',
@@ -237,7 +230,10 @@ const BuiltinExporters = [
                         dataset[0].push("geometry");
                     }
                     features.forEach(feature => {
-                        const row = exportAttrs.map(attr => xlsxCellValue(feature.properties[attr]));
+                        const row = exportAttrs.map(attr => {
+                            const value = feature.properties[attr];
+                            return MiscUtils.isNumeric(value) ? Number(value) : value;
+                        });
                         if (feature.geometry) {
                             const geomWkt = VectorLayerUtils.geoJSONGeomToWkt(feature.geometry);
                             if (geomWkt.length < 32768) {

--- a/utils/MiscUtils.js
+++ b/utils/MiscUtils.js
@@ -168,6 +168,9 @@ const MiscUtils = {
     capitalizeFirst(text) {
         return text.slice(0, 1).toUpperCase() + text.slice(1);
     },
+    isNumeric(value) {
+        return typeof value === 'string' && value.trim() !== '' && String(Number(value)) === value.trim();
+    },
     isBrightColor(color) {
         let r;
         let g;


### PR DESCRIPTION
Attribute values in the XLSX export are exported as strings, so numeric values show up in Excel/LibreCalc with prefixed `'` instead of only the numbers. Aggregating those columns is so not possible without additional work.

This PR adds a small helper function to convert numeric-looking strings cell wise to actual numbers. Data values with leading zeroes should be left as strings to avoid data loss (for example ID etc.)