### PR TITLE
fix: panoramax layers cleaned after plugin change

### DIFF
--- a/plugins/Panoramax.jsx
+++ b/plugins/Panoramax.jsx
@@ -92,6 +92,8 @@ class Panoramax extends React.Component {
                     this.addRecordingsMVT();
                 }
             }
+        } else if (prevProps.active && !this.props.active) {
+            this.cleanUp();
         } else if (this.state.selectionGeom && this.state.selectionGeom !== prevState.selectionGeom) {
             this.queryPoint(this.state.selectionGeom);
         }
@@ -104,12 +106,15 @@ class Panoramax extends React.Component {
         document.removeEventListener('keydown', this.handleKeyDown);
         this.onClose();
     }
-    onClose = () => {
-        this.props.setCurrentTask(null);
+    cleanUp = () => {
         this.props.removeLayer('panoramax-recordings');
         this.props.removeLayer('panoramaxselection');
         this.setState({ selectionGeom: null, queryData: null, lon: null, lat: null, selectionActive: null, yaw: null, currentTooltip: '', viewerInitialized: false });
         this.viewer?.select(null, null, true);
+    };
+    onClose = () => {
+        this.props.setCurrentTask(null);
+        this.cleanUp();
     };
     render() {
         if (!this.props.active) {

--- a/plugins/Panoramax.jsx
+++ b/plugins/Panoramax.jsx
@@ -114,7 +114,6 @@ class Panoramax extends React.Component {
     };
     onClose = () => {
         this.props.setCurrentTask(null);
-        this.cleanUp();
     };
     render() {
         if (!this.props.active) {


### PR DESCRIPTION
Bug: When the Panoramax plugin is open and the user doesn't click on the map but opens another plugin instead, the Panoramax custom layers remain visible and don't disappear.

Fix: A new Cleanup() function removes the layers, similarly to the existing onClose() function. It is now called whenever the plugin was active and becomes inactive — i.e. when the user opens another plugin.