### PR TITLE
fix: implodeLayers crashes when a layer added via ADD_LAYER_FEATURES has no srcid

### DIFF
--- a/reducers/layers.js
+++ b/reducers/layers.js
@@ -272,7 +272,6 @@ export default function layers(state = defaultState, action) {
             const newLayer = {
                 ...action.layer,
                 id: layerId,
-                srcid: action.layer.srcid ?? uuidv4(),
                 type: 'vector',
                 name: action.layer.name || layerId,
                 features: newFeatures,

--- a/reducers/layers.js
+++ b/reducers/layers.js
@@ -272,6 +272,7 @@ export default function layers(state = defaultState, action) {
             const newLayer = {
                 ...action.layer,
                 id: layerId,
+                srcid: action.layer.srcid ?? uuidv4(),
                 type: 'vector',
                 name: action.layer.name || layerId,
                 features: newFeatures,

--- a/utils/LayerUtils.js
+++ b/utils/LayerUtils.js
@@ -504,7 +504,7 @@ const LayerUtils = {
             const layer = entry.layer;
 
             // Attempt to merge with previous if possible (same srcid when defined)
-            if (prevlayer && prevlayer.srcid !== undefined && prevlayer?.srcid === layer.srcid) {
+            if (prevlayer && prevlayer.srcid !== undefined && prevlayer.srcid === layer.srcid) {
                 if (isEmpty(prevlayer.sublayers)) {
                     prevlayer.sublayers = layer.sublayers;
                 } else if (!isEmpty(layer.sublayers)) {

--- a/utils/LayerUtils.js
+++ b/utils/LayerUtils.js
@@ -504,7 +504,7 @@ const LayerUtils = {
             const layer = entry.layer;
 
             // Attempt to merge with previous if possible (same srcid when defined)
-            if (prevlayer && prevlayer.srcid !== undefined && prevlayer.srcid === layer.srcid) {
+            if (layer?.srcid && prevlayer.srcid === layer.srcid) {
                 if (isEmpty(prevlayer.sublayers)) {
                     prevlayer.sublayers = layer.sublayers;
                 } else if (!isEmpty(layer.sublayers)) {

--- a/utils/LayerUtils.js
+++ b/utils/LayerUtils.js
@@ -503,8 +503,8 @@ const LayerUtils = {
         for (const entry of exploded) {
             const layer = entry.layer;
 
-            // Attempt to merge with previous if possible
-            if (prevlayer?.srcid === layer.srcid) {
+            // Attempt to merge with previous if possible (same srcid when defined)
+            if (prevlayer && prevlayer.srcid !== undefined && prevlayer?.srcid === layer.srcid) {
                 if (isEmpty(prevlayer.sublayers)) {
                     prevlayer.sublayers = layer.sublayers;
                 } else if (!isEmpty(layer.sublayers)) {


### PR DESCRIPTION
Bug: creating a new layer feature calling `addLayerFeatures` without an srcid in parameters does not add a fallback uuidv4 value (unlike `addLayer`). Calling implodeLayers then causes React to crash, since the merge check  `prevlayer?.srcid === layer.srcid` resolved in undefined === undefined, resolving in `TypeError: can't access property "sublayers", prevlayer is null`

Fix: adds a default srcid fallback values in `addLayerFeatures` and hardens the check, verifying that prevlayers is not null / srcid is not undefined