### PR TITLE
Identify: add "if" URL parameter to identify features by attribute

### DIFF
--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -173,8 +173,7 @@ class Identify extends React.Component {
         exitTaskOnResultsClose: null,
         filterGeom: null,
         filterGeomModifiers: {},
-        importErrors: null,
-        pendingIdentifyFilter: null
+        importErrors: null
     };
     constructor(props) {
         super(props);
@@ -183,6 +182,7 @@ class Identify extends React.Component {
         this.fileinput.accept = "application/json";
         this.fileinput.addEventListener("change", this.fileSelected);
         this.viewerRef = null;
+        this.pendingIdentifyFilter = null;
     }
     componentDidUpdate(prevProps, prevState) {
         if (this.props.theme && !prevProps.theme) {
@@ -195,7 +195,7 @@ class Identify extends React.Component {
             } else if (startupParams.if) {
                 // Handled even when Identify is not the current identify tool.
                 // Deferred until the map filter is applied, see identifyFeaturesPending
-                this.setState({pendingIdentifyFilter: startupParams.if});
+                this.pendingIdentifyFilter = startupParams.if;
                 UrlParams.updateParams({if: undefined});
             } else if (this.props.enabled && this.props.startupState.identifyresultstate) {
                 this.deserializeResults(
@@ -210,7 +210,7 @@ class Identify extends React.Component {
                 this.clearResults();
             }
         }
-        if (this.state.pendingIdentifyFilter) {
+        if (this.pendingIdentifyFilter) {
             this.identifyFeaturesPending();
         }
         if (this.props.enabled) {
@@ -376,8 +376,8 @@ class Identify extends React.Component {
         if (awaitMapFilter && this.props.layerFilter?.filterParams === null) {
             return;
         }
-        const identifyFilter = this.state.pendingIdentifyFilter;
-        this.setState({pendingIdentifyFilter: null});
+        const identifyFilter = this.pendingIdentifyFilter;
+        this.pendingIdentifyFilter = null;
         this.identifyFeatures(identifyFilter);
     };
     identifyFeatures = (identifyFilter) => {

--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -274,8 +274,8 @@ class Identify extends React.Component {
             const appendResultsByDefault = this.props.appendResultsByDefault === true || (this.props.taskEnabled && this.props.appendResultsByDefault === "task");
             const identifyResults = this.props.click.modifiers.ctrl !== true && !appendResultsByDefault ? {} : state.identifyResults ?? {};
 
-            const params = {...this.props.params};
             const resultDisplayMode = this.props.taskEnabled ? (this.props.taskResultDisplayMode ?? this.props.resultDisplayMode) : this.props.resultDisplayMode;
+            const params = this.buildIdentifyParams();
             let queryableLayers = [];
             queryableLayers = IdentifyUtils.getQueryLayers(this.props.layers, this.props.map);
             queryableLayers.forEach(l => {
@@ -323,12 +323,8 @@ class Identify extends React.Component {
         const appendResultsByDefault = this.props.appendResultsByDefault === true || (this.props.taskEnabled && this.props.appendResultsByDefault === "task");
 
         let pendingRequests = 0;
-        const params = {...this.props.params};
         const resultDisplayMode = this.props.taskEnabled ? (this.props.taskResultDisplayMode ?? this.props.resultDisplayMode) : this.props.resultDisplayMode;
-        if (this.props.params.region_feature_count) {
-            params.feature_count = this.props.params.region_feature_count;
-            delete params.region_feature_count;
-        }
+        const params = this.buildIdentifyParams("region_feature_count");
         const requestFilterGeom = this.getRequestFilterGeomWkt(filterGeom);
         // Querying without the filter geometry would match the whole layer
         if (requestFilterGeom) {
@@ -347,6 +343,16 @@ class Identify extends React.Component {
             const identifyResults = state.filterGeomModifiers.ctrl !== true && !appendResultsByDefault ? {} : state.identifyResults ?? {};
             return {identifyResults: identifyResults, pendingRequests: pendingRequests, currentResultDisplayMode: resultDisplayMode};
         });
+    };
+    buildIdentifyParams = (featureCountParam = null) => {
+        const params = {...this.props.params};
+        if (featureCountParam && params[featureCountParam]) {
+            params.feature_count = params[featureCountParam];
+        }
+        // These are internal params, not GetFeatureInfo params
+        delete params.region_feature_count;
+        delete params.radius_feature_count;
+        return params;
     };
     getRequestFilterGeomWkt = (identifyGeom) => {
         const sourceFilterGeom = this.props.layerFilterGeom;

--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -17,6 +17,7 @@ import PropTypes from 'prop-types';
 import {v4 as uuidv4} from 'uuid';
 
 import {LayerRole, addLayer, addLayerFeatures, addMarker, removeMarker, removeLayer} from '../actions/layers';
+import {zoomToExtent, zoomToPoint} from '../actions/map';
 import {setCurrentTask} from '../actions/task';
 import IdentifyViewer from '../components/IdentifyViewer';
 import MapSelection from '../components/MapSelection';
@@ -27,10 +28,13 @@ import MenuButton from '../components/widgets/MenuButton';
 import NumberInput from '../components/widgets/NumberInput';
 import ConfigUtils from '../utils/ConfigUtils';
 import CoordinatesUtils from '../utils/CoordinatesUtils';
+import DataServiceExprUtils from '../utils/DataServiceExprUtils';
 import IdentifyUtils from '../utils/IdentifyUtils';
 import LayerUtils from '../utils/LayerUtils';
 import LocaleUtils from '../utils/LocaleUtils';
+import MapUtils from '../utils/MapUtils';
 import MeasureUtils from '../utils/MeasureUtils';
+import {UrlParams} from '../utils/PermaLinkUtils';
 import ServiceLayerUtils from '../utils/ServiceLayerUtils';
 import VectorLayerUtils from '../utils/VectorLayerUtils';
 
@@ -96,7 +100,7 @@ class Identify extends React.Component {
         iframeDialogsInitiallyDocked: PropTypes.bool,
         /** The initial radius units of the identify dialog in radius mode. One of 'm', 'ft', 'km', 'mi'. */
         initialRadiusUnits: PropTypes.string,
-        layerFilterGeom: PropTypes.object,
+        layerFilter: PropTypes.object,
         layers: PropTypes.array,
         /** How to handle long attribute names / values. */
         longAttributesDisplay: PropTypes.oneOf(["wrap", "ellipsis"]),
@@ -128,7 +132,9 @@ class Identify extends React.Component {
         taskEnabled: PropTypes.bool,
         /** Result display mode when Identify is run as a task. Defaults to `resultDisplayMode`. */
         taskResultDisplayMode: PropTypes.oneOf(["tree", "flat", "paginated", "table"]),
-        theme: PropTypes.object
+        theme: PropTypes.object,
+        zoomToExtent: PropTypes.func,
+        zoomToPoint: PropTypes.func
     };
     static defaultProps = {
         availableRegionModes: ['Region', 'Radius', 'Circle', 'Rectangle'],
@@ -167,7 +173,8 @@ class Identify extends React.Component {
         exitTaskOnResultsClose: null,
         filterGeom: null,
         filterGeomModifiers: {},
-        importErrors: null
+        importErrors: null,
+        pendingIdentifyFilter: null
     };
     constructor(props) {
         super(props);
@@ -178,14 +185,19 @@ class Identify extends React.Component {
         this.viewerRef = null;
     }
     componentDidUpdate(prevProps, prevState) {
-        if (this.props.enabled && this.props.theme && !prevProps.theme) {
+        if (this.props.theme && !prevProps.theme) {
             const startupParams = this.props.startupParams;
             const haveIc = ["1", "true"].includes((startupParams.ic || "").toLowerCase());
             const c = (startupParams.c || "").split(/[;,]/g).map(x => parseFloat(x) || 0);
-            if (haveIc && c.length === 2) {
+            if (this.props.enabled && haveIc && c.length === 2) {
                 const mapCrs = this.props.theme.mapCrs;
                 this.identifyPoint(CoordinatesUtils.reproject(c, startupParams.crs || mapCrs, mapCrs));
-            } else if (this.props.startupState.identifyresultstate) {
+            } else if (startupParams.if) {
+                // Handled even when Identify is not the current identify tool.
+                // Deferred until the map filter is applied, see identifyFeaturesPending
+                this.setState({pendingIdentifyFilter: startupParams.if});
+                UrlParams.updateParams({if: undefined});
+            } else if (this.props.enabled && this.props.startupState.identifyresultstate) {
                 this.deserializeResults(
                     {...this.props.startupState.identifyresultstate.identifyResults},
                     this.props.startupState.identifyresultstate.currentResultDisplayMode
@@ -197,6 +209,9 @@ class Identify extends React.Component {
             if (this.props.clearResultsOnClose) {
                 this.clearResults();
             }
+        }
+        if (this.state.pendingIdentifyFilter) {
+            this.identifyFeaturesPending();
         }
         if (this.props.enabled) {
             if (this.props.identifySearchResults && this.props.currentSearchResult && this.props.currentSearchResult !== prevProps.currentSearchResult) {
@@ -354,8 +369,78 @@ class Identify extends React.Component {
         delete params.radius_feature_count;
         return params;
     };
+    identifyFeaturesPending = () => {
+        // MapFilter applies the startup filter asynchronously, wait for it so that
+        // the identify filter can be combined with the map filter
+        const awaitMapFilter = this.props.startupParams.f && ConfigUtils.havePlugin("MapFilter");
+        if (awaitMapFilter && this.props.layerFilter?.filterParams === null) {
+            return;
+        }
+        const identifyFilter = this.state.pendingIdentifyFilter;
+        this.setState({pendingIdentifyFilter: null});
+        this.identifyFeatures(identifyFilter);
+    };
+    identifyFeatures = (identifyFilter) => {
+        const layerEntries = IdentifyUtils.parseIdentifyFilter(identifyFilter, this.props.layers, this.props.map);
+        const resultDisplayMode = this.props.taskEnabled ? (this.props.taskResultDisplayMode ?? this.props.resultDisplayMode) : this.props.resultDisplayMode;
+        const params = this.buildIdentifyParams("region_feature_count");
+        const requests = layerEntries.map(({layer, entries}) => {
+            // Start from the filters currently active on the layer, so that no feature
+            // which the map filter hides is identified
+            const filterParams = {...this.props.layerFilter?.filterParams};
+            entries.forEach(entry => {
+                const key = layer.wms_name + "#" + entry.sublayer;
+                filterParams[key] = DataServiceExprUtils.joinExpressions(filterParams[key], entry.expr);
+            });
+            // buildWMSLayerParams merges in the layer permission filter
+            const wmsParams = LayerUtils.buildWMSLayerParams(layer, {filterParams: filterParams, filterGeom: this.props.layerFilter?.filterGeom}).params;
+            if (!wmsParams.FILTER) {
+                /* eslint-disable-next-line */
+                console.warn("Cannot build an identify filter for layer: " + layer.name);
+                return null;
+            }
+            const queryLayers = [...new Set(entries.map(entry => entry.sublayer))].join(",");
+            return {layer: layer, request: IdentifyUtils.buildFilterRequest(layer, queryLayers, wmsParams.FILTER_GEOM, this.props.map, {...params, filter: wmsParams.FILTER})};
+        }).filter(Boolean);
+        if (isEmpty(requests)) {
+            return;
+        }
+        const bboxes = [];
+        let remaining = requests.length;
+        requests.forEach(({layer, request}) => {
+            IdentifyUtils.sendRequest(request, (response) => {
+                this.setState((state) => ({pendingRequests: state.pendingRequests - 1}));
+                if (response) {
+                    const results = this.parseResult(response, layer, request.params.info_format, null);
+                    // No click position, use the feature center
+                    Object.values(results).flat().forEach(feature => {
+                        if (feature.bbox) {
+                            bboxes.push(feature.bbox);
+                            feature.clickPos = [0.5 * (feature.bbox[0] + feature.bbox[2]), 0.5 * (feature.bbox[1] + feature.bbox[3])];
+                        } else {
+                            feature.clickPos = this.props.map.center;
+                        }
+                    });
+                }
+                if (--remaining === 0 && !isEmpty(bboxes)) {
+                    const extent = bboxes.reduce((res, bbox) => ([
+                        Math.min(res[0], bbox[0]), Math.min(res[1], bbox[1]),
+                        Math.max(res[2], bbox[2]), Math.max(res[3], bbox[3])
+                    ]));
+                    if (extent[0] !== extent[2] || extent[1] !== extent[3]) {
+                        this.props.zoomToExtent(extent, this.props.map.projection);
+                    } else {
+                        // Degenerate extent (single point feature)
+                        const zoom = MapUtils.computeZoom(this.props.map.scales, this.props.theme.minSearchScaleDenom || 1000);
+                        this.props.zoomToPoint([extent[0], extent[1]], zoom, this.props.map.projection);
+                    }
+                }
+            });
+        });
+        this.setState({identifyResults: {}, pendingRequests: requests.length, currentResultDisplayMode: resultDisplayMode});
+    };
     getRequestFilterGeomWkt = (identifyGeom) => {
-        const sourceFilterGeom = this.props.layerFilterGeom;
+        const sourceFilterGeom = this.props.layerFilter?.filterGeom;
         if (!sourceFilterGeom) return VectorLayerUtils.geoJSONGeomToWkt(identifyGeom);
         try {
             const intersection = intersect(featureCollection([
@@ -661,7 +746,7 @@ export default connect((state) => {
         currentSearchResult: state.search.currentResult,
         enabled: enabled,
         taskEnabled: state.task.id === "Identify",
-        layerFilterGeom: state.layers.filter?.filterGeom,
+        layerFilter: state.layers.filter,
         layers: state.layers.flat,
         map: state.map,
         selection: state.selection,
@@ -675,5 +760,7 @@ export default connect((state) => {
     addMarker: addMarker,
     removeMarker: removeMarker,
     removeLayer: removeLayer,
-    setCurrentTask: setCurrentTask
+    setCurrentTask: setCurrentTask,
+    zoomToExtent: zoomToExtent,
+    zoomToPoint: zoomToPoint
 })(Identify);

--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -330,16 +330,19 @@ class Identify extends React.Component {
             delete params.region_feature_count;
         }
         const requestFilterGeom = this.getRequestFilterGeomWkt(filterGeom);
-        queryableLayers.forEach(layer => {
-            const request = IdentifyUtils.buildFilterRequest(layer, layer.queryLayers.join(","), requestFilterGeom, this.props.map, params);
-            ++pendingRequests;
-            IdentifyUtils.sendRequest(request, (response) => {
-                this.setState((state) => ({pendingRequests: state.pendingRequests - 1}));
-                if (response) {
-                    this.parseResult(response, layer, request.params.info_format, center);
-                }
+        // Querying without the filter geometry would match the whole layer
+        if (requestFilterGeom) {
+            queryableLayers.forEach(layer => {
+                const request = IdentifyUtils.buildFilterRequest(layer, layer.queryLayers.join(","), requestFilterGeom, this.props.map, params);
+                ++pendingRequests;
+                IdentifyUtils.sendRequest(request, (response) => {
+                    this.setState((state) => ({pendingRequests: state.pendingRequests - 1}));
+                    if (response) {
+                        this.parseResult(response, layer, request.params.info_format, center);
+                    }
+                });
             });
-        });
+        }
         this.setState(state => {
             const identifyResults = state.filterGeomModifiers.ctrl !== true && !appendResultsByDefault ? {} : state.identifyResults ?? {};
             return {identifyResults: identifyResults, pendingRequests: pendingRequests, currentResultDisplayMode: resultDisplayMode};

--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -193,8 +193,7 @@ class Identify extends React.Component {
                 const mapCrs = this.props.theme.mapCrs;
                 this.identifyPoint(CoordinatesUtils.reproject(c, startupParams.crs || mapCrs, mapCrs));
             } else if (startupParams.if) {
-                // Handled even when Identify is not the current identify tool.
-                // Deferred until the map filter is applied, see identifyFeaturesPending
+                // Handled even when Identify is not the current identify tool, see identifyFeaturesPending
                 this.pendingIdentifyFilter = startupParams.if;
                 UrlParams.updateParams({if: undefined});
             } else if (this.props.enabled && this.props.startupState.identifyresultstate) {
@@ -370,8 +369,8 @@ class Identify extends React.Component {
         return params;
     };
     identifyFeaturesPending = () => {
-        // MapFilter applies the startup filter asynchronously, wait for it so that
-        // the identify filter can be combined with the map filter
+        // MapFilter applies the startup filter behind a debounce, wait for it so that the
+        // identify filter is combined with the map filter rather than replacing it
         const awaitMapFilter = this.props.startupParams.f && ConfigUtils.havePlugin("MapFilter");
         if (awaitMapFilter && this.props.layerFilter?.filterParams === null) {
             return;

--- a/plugins/Identify.jsx
+++ b/plugins/Identify.jsx
@@ -489,7 +489,7 @@ class Identify extends React.Component {
     };
     onWindowClose = () => {
         this.clearResults();
-        if (this.state.exitTaskOnResultsClose || this.props.exitTaskOnResultsClose) {
+        if (this.props.taskEnabled && (this.state.exitTaskOnResultsClose || this.props.exitTaskOnResultsClose)) {
             this.props.setCurrentTask(null);
         }
     };

--- a/plugins/MapFilter.jsx
+++ b/plugins/MapFilter.jsx
@@ -207,10 +207,8 @@ class MapFilter extends React.Component {
                     if (replacedExpr === null) {
                         /* eslint-disable-next-line */
                         console.warn("Invalid filter expression: " + JSON.stringify(expression));
-                    } else if (layerExpressions[layer]) {
-                        layerExpressions[layer].push('and', replacedExpr);
                     } else {
-                        layerExpressions[layer] = [replacedExpr];
+                        layerExpressions[layer] = DataServiceExprUtils.joinExpressions(layerExpressions[layer], replacedExpr);
                     }
                 });
             }
@@ -223,11 +221,7 @@ class MapFilter extends React.Component {
                 } catch {
                     return;
                 }
-                if (layerExpressions[entry.layer]) {
-                    layerExpressions[entry.layer].push('and', expr);
-                } else {
-                    layerExpressions[entry.layer] = [expr];
-                }
+                layerExpressions[entry.layer] = DataServiceExprUtils.joinExpressions(layerExpressions[entry.layer], expr);
             }
         });
         const timeRange = this.state.filters.__timefilter?.active ? {

--- a/plugins/map/LocateSupport.jsx
+++ b/plugins/map/LocateSupport.jsx
@@ -97,7 +97,7 @@ class LocateSupport extends React.Component {
         const startupMode = this.props.startupMode.toUpperCase();
         const startupParams = this.props.startupParams;
         const highlightCenter = ["true", "1"].includes((startupParams.hc || "").toLowerCase());
-        const searchParams = startupParams.hp || startupParams.hf || startupParams.st;
+        const searchParams = startupParams.hp || startupParams.hf || startupParams.st || startupParams.if;
         if (startupMode !== "DISABLED" && !searchParams && !highlightCenter) {
             this.requestedMode = startupMode;
             this.start();

--- a/utils/DataServiceExprUtils.js
+++ b/utils/DataServiceExprUtils.js
@@ -63,6 +63,22 @@ const DataServiceExprUtils = {
     },
 
     /**
+     * Formats a single right-hand value of a subexpression
+     * @param {string | number | null} value Value
+     * @returns {string} Formatted value
+     */
+    formatFilterValue(value) {
+        if (typeof value === "number") {
+            return String(value);
+        } else if (value === null) {
+            return "NULL";
+        } else {
+            // Escaping as QgsExpression::quotedString does
+            return `'${String(value).replace(/'/g, "''").replace(/\\/g, "\\\\")}'`;
+        }
+    },
+
+    /**
      * Formats a valid expression array into a string
      * @param {DataServiceExpression} expr Expression
      * @returns {string} Formatted expression
@@ -70,14 +86,10 @@ const DataServiceExprUtils = {
     formatFilterExpr(expr) {
         if (this.isSubExpression(expr)) {
             const op = expr[1].toUpperCase();
-            if (typeof expr[2] === "number") {
-                return `"${expr[0]}" ${op} ${expr[2]}`;
-            } else if (expr[2] === null) {
-                return `"${expr[0]}" ${op} NULL`;
-            } else if (Array.isArray(expr[2])) {
-                return `"${expr[0]}" ${op} ( ${expr[2].join(' , ')} )`;
+            if (Array.isArray(expr[2])) {
+                return `"${expr[0]}" ${op} ( ${expr[2].map(value => this.formatFilterValue(value)).join(' , ')} )`;
             } else {
-                return `"${expr[0]}" ${op} '${expr[2].replace("'", "\\'")}'`;
+                return `"${expr[0]}" ${op} ${this.formatFilterValue(expr[2])}`;
             }
         } else {
             return "( " + expr.map((entry, idx) => (idx % 2) === 0 ? this.formatFilterExpr(entry) : entry.toUpperCase()).join(" ") + " )";

--- a/utils/DataServiceExprUtils.js
+++ b/utils/DataServiceExprUtils.js
@@ -40,6 +40,17 @@ const DataServiceExprUtils = {
     },
 
     /**
+     * Appends an expression to an expression array
+     * @param {ExpressionArray | null | undefined} current Current expression array, if any
+     * @param {DataServiceExpression} expr Expression to append
+     * @param {JoinOperator} op Join operator
+     * @returns {ExpressionArray} Expression array containing both expressions
+     */
+    joinExpressions(current, expr, op = 'and') {
+        return current ? [...current, op, expr] : [expr];
+    },
+
+    /**
      * Replaces variable placeholders in a Data Service Expression
      * @param {DataServiceExpression} expr Expression
      * @param {Object<string, any>} values Key-values dictionary

--- a/utils/DataServiceExprUtils.js
+++ b/utils/DataServiceExprUtils.js
@@ -10,7 +10,7 @@
 
 const DataServiceExprUtils = {
     isSubExpression(expr) {
-        return Array.isArray(expr) && expr.length === 3 && typeof expr[0] === "string";
+        return Array.isArray(expr) && expr.length === 3 && typeof expr[0] === "string" && typeof expr[1] === "string";
     },
     isJoinOperator(expr) {
         return typeof(expr) === "string" && ["and", "or"].includes(expr.toLowerCase());

--- a/utils/IdentifyUtils.js
+++ b/utils/IdentifyUtils.js
@@ -16,6 +16,7 @@ import {v4 as uuidv4} from 'uuid';
 import {LayerRole} from '../actions/layers';
 import ConfigUtils from '../utils/ConfigUtils';
 import CoordinatesUtils from '../utils/CoordinatesUtils';
+import DataServiceExprUtils from '../utils/DataServiceExprUtils';
 import LayerUtils from '../utils/LayerUtils';
 import MapUtils from '../utils/MapUtils';
 import VectorLayerUtils from './VectorLayerUtils';
@@ -109,6 +110,65 @@ const IdentifyUtils = {
             result = result.concat(layers);
         });
         return result;
+    },
+    resolveIdentifyLayer(queryableLayers, layerRef) {
+        // A layer reference is either a plain sublayer name, or the `<wms_name>#<sublayer>`
+        // form used by the custom filter entries of the `f` parameter
+        const [wmsName, sublayer] = layerRef.includes("#") ? layerRef.split("#") : [null, layerRef];
+        const candidates = queryableLayers.filter(l => l.queryLayers.includes(sublayer) && (!wmsName || l.wms_name === wmsName));
+        if (isEmpty(candidates)) {
+            /* eslint-disable-next-line */
+            console.warn("No queryable layer found for identify features entry: " + layerRef);
+            return null;
+        }
+        // Only layers with a wms_name can carry a filter, see LayerUtils.buildWMSLayerParams
+        const filterable = candidates.filter(l => l.wms_name);
+        if (isEmpty(filterable)) {
+            /* eslint-disable-next-line */
+            console.warn("Layer does not support identifying features by attribute: " + layerRef);
+            return null;
+        }
+        if (filterable.length > 1) {
+            /* eslint-disable-next-line */
+            console.warn("Ambiguous identify features layer '" + layerRef + "', use one of: " + filterable.map(l => l.wms_name + "#" + sublayer).join(", "));
+            return null;
+        }
+        return [filterable[0], sublayer];
+    },
+    parseIdentifyFilter(identifyFilter, layers, map) {
+        let entries;
+        try {
+            entries = JSON.parse(identifyFilter);
+        } catch {
+            /* eslint-disable-next-line */
+            console.warn("Invalid identify features parameter: " + identifyFilter);
+            return [];
+        }
+        if (!entries || typeof entries !== "object" || Array.isArray(entries)) {
+            /* eslint-disable-next-line */
+            console.warn("Identify features parameter must be a layer to expression object: " + identifyFilter);
+            return [];
+        }
+        const queryableLayers = this.getQueryLayers(layers, map);
+        return Object.entries(entries).reduce((layerEntries, [layerRef, expr]) => {
+            if (!DataServiceExprUtils.isValid(expr)) {
+                /* eslint-disable-next-line */
+                console.warn("Invalid identify features expression for layer " + layerRef + ": " + JSON.stringify(expr));
+                return layerEntries;
+            }
+            const resolved = this.resolveIdentifyLayer(queryableLayers, layerRef);
+            if (!resolved) {
+                return layerEntries;
+            }
+            const [layer, sublayer] = resolved;
+            const layerEntry = layerEntries.find(l => l.layer === layer);
+            if (layerEntry) {
+                layerEntry.entries.push({sublayer: sublayer, expr: expr});
+            } else {
+                layerEntries.push({layer: layer, entries: [{sublayer: sublayer, expr: expr}]});
+            }
+            return layerEntries;
+        }, []);
     },
     buildRequest(layer, queryLayers, center, map, options = {}) {
         const size = [101, 101];

--- a/utils/IdentifyUtils.js
+++ b/utils/IdentifyUtils.js
@@ -138,7 +138,7 @@ const IdentifyUtils = {
         const params = {
             feature_count: 100,
             filter: layer.params.FILTER ?? '',
-            FILTER_GEOM: filterGeom,
+            ...(filterGeom ? {FILTER_GEOM: filterGeom} : {}),
             ...options
         };
         return identifyRequestParams(layer, queryLayers, map.projection, params);

--- a/utils/PermaLinkUtils.js
+++ b/utils/PermaLinkUtils.js
@@ -71,7 +71,7 @@ export const UrlParams = {
         }
     },
     clear() {
-        const clearKeys = ['k', 't', 'l', 'bl', 'bk', 'c', 'hc', 'ic', 's', 'e', 'crs', 'st', 'sp', 'f', 'v', 'vp', 'v3d', 'bl3d', 'task'];
+        const clearKeys = ['k', 't', 'l', 'bl', 'bk', 'c', 'hc', 'ic', 'if', 's', 'e', 'crs', 'st', 'sp', 'f', 'v', 'vp', 'v3d', 'bl3d', 'task'];
         this.updateParams(clearKeys.reduce((res, key) => ({...res, [key]: undefined}), {}), true);
     },
     getFullUrl() {


### PR DESCRIPTION
Fixes #703.

Adds an `if` URL parameter which identifies features by attribute on startup: the matching features are queried via WMS GetFeatureInfo, listed in the identify results window, highlighted on the map, and the map is zoomed to their combined extent. This lets an external application deep-link into QWC using its own business identifiers, which is what the generic search (`st`, single fuzzy result), the fulltext search parameters (`hp`/`hf`, point based and requiring a dedicated service) and the theme filter (`f`, which hides non-matching features instead of highlighting them) cannot do today.

## Parameter format

The value is a JSON object mapping a layer to a data service filter expression, which is the same shape as the `filter` of a predefined map filter:

```
if={"<layer>": <data_service_filter_expression>, ...}
```

Examples of valid url with if parameter:
```
?t=qwc_demo&if={"countries":["name","IN",["Germany","Austria","Poland"]]}
?t=qwc_demo&if={"countries":["name","=","France"],"country_names":["name","=","France"]}
?t=qwc_demo&if={"countries":[["pop_est",">",200000000],"or",["name","=","Austria"]]}
```

`<layer>` is the WMS name of a theme layer, optionally prefixed as `<theme_wms_name>#<layer>`, which is required when several WMS layers in the map expose the same layer name and is also what lets an entry be copied straight out of an `f` permalink. Ambiguous unprefixed names are refused with a console warning naming the qualified spellings, rather than silently identifying the wrong layer.

## Limitations

- Like the `f` custom filters, this relies on `wms_name` being present on the theme layer, so it works with themes generated by `qwc-config-generator` and not with the standalone `scripts/themesConfig.js` output.
- The target layer must be visible and queryable when the application starts, and the theme `identifyTool` must be `Identify`.

## Verification

The repository has no test framework, so this was verified against a `qwc-docker` deployment of the demo theme, driving the built viewer headlessly and inspecting the GetFeatureInfo request, the panel contents, the resulting map view and the URL.

### Screenshot

Result for `?t=qwc_demo&if={"countries":["name","IN",["Germany","Austria","Poland"]]}`:
<img width="1660" height="1143" alt="Screenshot_2026-08-19_16-38-04" src="https://github.com/user-attachments/assets/651bfe4a-208d-49ff-b143-c1308b35bd25" />

## Notes

The documentation update is here: [qwc-services.github.io/pull/40](https://github.com/qwc-services/qwc-services.github.io/pull/40)

## Sponsor

This work is sponsored by the Eurométropole de Strasbourg (EMS), in coordination with @cazitouni .