### PR TITLE
Replace vulnerable xlsx dependency with maintained fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
                 "url": "^0.11.4",
                 "utif": "^3.1.0",
                 "uuid": "^14.0.0",
-                "xlsx": "^0.18.5"
+                "xlsx": "npm:@stackline/xlsx@^1.0.6"
             },
             "bin": {
                 "qwc_build_iconfont": "scripts/makeIconkit.js",
@@ -4474,13 +4474,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/adler-32": {
-            "version": "1.3.1",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -5101,17 +5094,6 @@
             ],
             "license": "CC-BY-4.0"
         },
-        "node_modules/cfb": {
-            "version": "1.2.2",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "adler-32": "~1.3.0",
-                "crc-32": "~1.2.0"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "dev": true,
@@ -5246,13 +5228,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/codepage": {
-            "version": "1.15.0",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.8"
             }
         },
         "node_modules/color-convert": {
@@ -5458,16 +5433,6 @@
         "node_modules/core-util-is": {
             "version": "1.0.3",
             "license": "MIT"
-        },
-        "node_modules/crc-32": {
-            "version": "1.2.2",
-            "license": "Apache-2.0",
-            "bin": {
-                "crc32": "bin/crc32.njs"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
         },
         "node_modules/cross-fetch": {
             "version": "3.2.0",
@@ -6808,13 +6773,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/frac": {
-            "version": "1.1.2",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.8"
             }
         },
         "node_modules/fresh": {
@@ -10992,16 +10950,6 @@
             "version": "1.0.2",
             "license": "BDS-3-Clause"
         },
-        "node_modules/ssf": {
-            "version": "0.11.2",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "frac": "~1.1.2"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/statuses": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -12425,20 +12373,6 @@
             "version": "1.5.2",
             "license": "MIT"
         },
-        "node_modules/wmf": {
-            "version": "1.0.2",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
-        "node_modules/word": {
-            "version": "0.3.0",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/word-wrap": {
             "version": "1.2.5",
             "dev": true,
@@ -12496,22 +12430,13 @@
             }
         },
         "node_modules/xlsx": {
-            "version": "0.18.5",
+            "name": "@stackline/xlsx",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@stackline/xlsx/-/xlsx-1.0.6.tgz",
+            "integrity": "sha512-9huNkQPK7yQGUfO5wXixydxjh0Zi8y+0wBCIMHdrscXrd2AULCp+ck6ZhZNH5FQROL98PLvfxVy5wRSRosjmhg==",
             "license": "Apache-2.0",
-            "dependencies": {
-                "adler-32": "~1.3.0",
-                "cfb": "~1.2.1",
-                "codepage": "~1.15.0",
-                "crc-32": "~1.2.1",
-                "ssf": "~0.11.2",
-                "wmf": "~1.0.1",
-                "word": "~0.3.0"
-            },
-            "bin": {
-                "xlsx": "bin/xlsx.njs"
-            },
             "engines": {
-                "node": ">=0.8"
+                "node": ">=20"
             }
         },
         "node_modules/xml-naming": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "url": "^0.11.4",
         "utif": "^3.1.0",
         "uuid": "^14.0.0",
-        "xlsx": "^0.18.5"
+        "xlsx": "npm:@stackline/xlsx@^1.0.6"
     },
     "devDependencies": {
         "@babel/cli": "^7.28.6",


### PR DESCRIPTION
## Summary

Replace `xlsx@^0.18.5` with the npm alias
`xlsx@npm:@stackline/xlsx@^1.0.6`. The dependency is still installed and
imported as `xlsx`, so no QWC2 source changes are needed.

The currently resolved release is affected by:

- https://github.com/advisories/GHSA-4r6h-8v6p-xvw6
- https://github.com/advisories/GHSA-5pgg-2g8v-p4x9

`@stackline/xlsx` is an independent Apache-2.0 SheetJS-compatible fork with
regression tests for both advisories. It requires Node 20 or newer and has no
runtime dependencies. QWC2 CI currently builds with Node 24.

## Verification

- `npm run prod`: passed (webpack production build; existing size warnings only)
- XLSX write/read round-trip: passed
- Dangerous-key/prototype-pollution smoke test: passed
- `npm audit`: no advisory for `xlsx` or `@stackline/xlsx` in the resolved tree

Disclosure: I maintain `@stackline/xlsx`. The package and source are available
at https://www.npmjs.com/package/@stackline/xlsx and
https://github.com/alexandroit/sheetjs.
