### PR TITLE
Update feature status based on data presence

### DIFF
--- a/components/AttributeForm.jsx
+++ b/components/AttributeForm.jsx
@@ -239,7 +239,7 @@ class AttributeForm extends React.Component {
             type: "Feature",
             properties: {...initialProperties}
         }, this.props.iface, this.props.editContext.mapPrefix, this.props.map.projection, newRelFeature => {
-            newRelFeature.__status__ = data ? "new" : "empty"
+            newRelFeature.__status__ = initialProperties ? "new" : "empty"
             if (editConfig.geomType === null) {
                 newRelFeature.geometry = null;
             }

--- a/components/AttributeForm.jsx
+++ b/components/AttributeForm.jsx
@@ -239,7 +239,7 @@ class AttributeForm extends React.Component {
             type: "Feature",
             properties: {...initialProperties}
         }, this.props.iface, this.props.editContext.mapPrefix, this.props.map.projection, newRelFeature => {
-            newRelFeature.__status__ = "empty";
+            newRelFeature.__status__ = data ? "new" : "empty"
             if (editConfig.geomType === null) {
                 newRelFeature.geometry = null;
             }

--- a/components/AttributeForm.jsx
+++ b/components/AttributeForm.jsx
@@ -232,7 +232,7 @@ class AttributeForm extends React.Component {
             }
         }
     };
-    addRelationRecord = (table, initialProperties = {}) => {
+    addRelationRecord = (table, initialProperties = null) => {
         const newRelationValues = {...this.props.editContext.feature.relationValues};
         const editConfig = this.props.editConfigs[this.props.editContext.mapPrefix][table.split('.').slice(-1)];
         getFeatureTemplate(editConfig, {


### PR DESCRIPTION
the 'new' status is important, otherwise the relation values do not get saved correctly, cf. https://github.com/mki-c2c/qwc2/pull/1/changes