### PR TITLE
MapUtils: derive getZoomForExtent from the exact zoom level so the extent always fits

### DIFF
--- a/components/IdentifyViewer.jsx
+++ b/components/IdentifyViewer.jsx
@@ -971,7 +971,7 @@ class IdentifyViewer extends React.Component {
         let zoom = 0;
         const maxZoom = MapUtils.computeZoom(this.props.map.scales, this.props.theme.minSearchScaleDenom || 1000);
         if (result.bbox[0] !== result.bbox[2] && result.bbox[1] !== result.bbox[3]) {
-            zoom = Math.max(0, MapUtils.getZoomForExtent(result.bbox, this.props.map.resolutions, this.props.map.size, 0, maxZoom + 1) - 1);
+            zoom = MapUtils.getZoomForExtent(result.bbox, this.props.map.resolutions, this.props.map.size, 0, maxZoom);
         } else {
             zoom = maxZoom;
         }

--- a/components/SearchBox.jsx
+++ b/components/SearchBox.jsx
@@ -932,7 +932,7 @@ class SearchBox extends React.Component {
         } else {
             const maxZoom = MapUtils.computeZoom(this.props.map.scales, this.props.theme.minSearchScaleDenom || this.props.searchOptions.minScaleDenom);
             if (bbox[0] !== bbox[2] && bbox[1] !== bbox[3]) {
-                zoom = Math.max(0, MapUtils.getZoomForExtent(bbox, this.props.map.resolutions, this.props.map.size, 0, maxZoom + 1) - 1);
+                zoom = MapUtils.getZoomForExtent(bbox, this.props.map.resolutions, this.props.map.size, 0, maxZoom);
             } else {
                 zoom = maxZoom;
             }

--- a/extra/plugins/PlotInfoTool.jsx
+++ b/extra/plugins/PlotInfoTool.jsx
@@ -346,7 +346,7 @@ class PlotInfoTool extends React.Component {
             this.setState({plotInfo: plotInfo, currentPlot: 0, expandedInfo: null, expandedInfoData: null});
             if (plotInfo) {
                 const bounds = CoordinatesUtils.reprojectBbox(plotInfo[0].bbox, 'EPSG:2056', this.props.map.projection);
-                const zoom = MapUtils.getZoomForExtent(bounds, this.props.map.resolutions, this.props.map.size, 0, this.props.map.scales.length - 1) - 1;
+                const zoom = MapUtils.getZoomForExtent(bounds, this.props.map.resolutions, this.props.map.size, 0, this.props.map.scales.length - 1);
                 this.props.zoomToPoint([0.5 * (bounds[0] + bounds[2]), 0.5 * (bounds[1] + bounds[3])], zoom, 'EPSG:2056');
                 let url = query.query.replace('$egrid$', egrid);
                 if (!url.startsWith('http')) {

--- a/utils/MapUtils.js
+++ b/utils/MapUtils.js
@@ -97,12 +97,9 @@ const MapUtils = {
         const yResolution = Math.abs(hExtent / mapSize.height);
         const extentResolution = Math.max(xResolution, yResolution);
 
-        const zoom = this.computeZoom(resolutions, extentResolution);
-        if (ConfigUtils.getConfigProp("allowFractionalZoom") === true) {
-            return Math.max(minZoom, Math.min(zoom, maxZoom));
-        } else {
-            return Math.max(minZoom, Math.min(Math.round(zoom), maxZoom));
-        }
+        const fractionalZoom = this.computeFractionalZoom(resolutions, extentResolution);
+        const fittingZoom = ConfigUtils.getConfigProp("allowFractionalZoom") === true ? fractionalZoom : Math.floor(fractionalZoom);
+        return Math.max(minZoom, Math.min(fittingZoom, maxZoom));
     },
     /**
      * Calculates the extent for the provided center and zoom level
@@ -168,6 +165,22 @@ const MapUtils = {
         return list[lower] * (1 - frac) + list[upper] * frac;
     },
     /**
+     * Compute the exact, fractional zoom level matching the specified scale or resolution.
+     *
+     * @param list {Array} List of scales or resolutions.
+     * @param value (number) Scale or resolution.
+     * @return Fractional zoom level matching the specified scale or resolution.
+     */
+    computeFractionalZoom(list, value) {
+        let index = 0;
+        for (let i = 1; i < list.length - 1; ++i) {
+            if (value <= list[i]) {
+                index = i;
+            }
+        }
+        return index + (value - list[index]) / (list[index + 1] - list[index]);
+    },
+    /**
      * Compute the (possibly fractional) zoom level matching the specified scale or resolution.
      *
      * @param list {Array} List of scales or resolutions.
@@ -176,13 +189,7 @@ const MapUtils = {
      */
     computeZoom(list, value) {
         if (ConfigUtils.getConfigProp("allowFractionalZoom") === true) {
-            let index = 0;
-            for (let i = 1; i < list.length - 1; ++i) {
-                if (value <= list[i]) {
-                    index = i;
-                }
-            }
-            return index + (value - list[index]) / (list[index + 1] - list[index]);
+            return this.computeFractionalZoom(list, value);
         } else {
             let closestVal = Math.abs(value - list[0]);
             let closestIdx = 0;


### PR DESCRIPTION
`MapUtils.getZoomForExtent` documents itself as returning "the zoom level fitting the extent", but with `allowFractionalZoom` disabled (the default) it can return a level which is zoomed in past the requested extent, cutting off part of it.

## Why it matters

Reported by users of the `if` URL parameter added in #730, which zooms to the combined extent of the identified features. When the extent falls in the bad range, the map lands one level too deep and the features the URL is about are outside the viewport, even though the identify results window lists them.

The screenshots below are the same URL against the same theme, before and after the fix. Two trees 123 m apart are identified by attribute. Before, the map goes to 1:500 and both features are off screen. After, it goes to 1:1000 and both are visible:

| | |
|---|---|
| before | <img width="1280" height="800" alt="zoom-fit-before" src="https://github.com/user-attachments/assets/874db746-24dc-49df-92c0-ca2d74159ed8" /> |
| after | <img width="1280" height="800" alt="zoom-fit-after" src="https://github.com/user-attachments/assets/0c400e09-097f-4dd9-8dd8-d154e664cf9e" /> |

## Other affected features

Some other features seems to compensate this issue by dropping from one level of zoom and I updated since it's not needed anymore. In my opinion, it can only improve the fitting of the zoom extent but maybe I'm missing some edge cases... https://github.com/qgis/qwc2/pull/739/commits/93b01522ceea66b7005d03a62ceb06f3b5729d9f

## Notes

- No behaviour change when `allowFractionalZoom` is enabled.
- `computeFractionalZoom` is a straight extraction, not a rewrite, so `computeZoom` returns exactly what it returned before.
