### PR TITLE
DxfUtils, FileImportUtils: fix all DXF entities importing in the same color

### DIFF
--- a/utils/DxfUtils.js
+++ b/utils/DxfUtils.js
@@ -73,6 +73,55 @@ export function unescapeDxfUnicode(text) {
     return text.replace(/\\U\+([0-9A-Fa-f]{4})/g, (match, hex) => String.fromCharCode(parseInt(hex, 16)));
 }
 
+const COLOR_BYBLOCK = 0;
+const COLOR_BYLAYER = 256;
+
+const rgbToHex = (rgb) => "#" + rgb.map(v => v.toString(16).padStart(2, "0")).join("");
+
+// AutoCAD draws on black, so an ACI black or white mostly means "no color was chosen"
+const isDefaultAciColor = (rgb) => rgb.every(v => v === 0) || rgb.every(v => v === 255);
+
+// dxf has no handler for group code 420 (24 bit true color), so it has to be read off the raw file
+function extractTrueColors(text) {
+    const lines = text.split(/\r\n|\r|\n/);
+    const trueColors = {};
+    let handle = null;
+    for (let i = 0; i + 1 < lines.length; i += 2) {
+        const code = lines[i].trim();
+        if (code === "0") {
+            handle = null;
+        } else if (code === "5") {
+            handle = lines[i + 1].trim();
+        } else if (code === "420" && handle !== null) {
+            const value = parseInt(lines[i + 1].trim(), 10);
+            if (value >= 0) {
+                trueColors[handle] = [(value >> 16) & 255, (value >> 8) & 255, value & 255];
+            }
+        }
+    }
+    return trueColors;
+}
+
+// Returns a resolveColor(entity) yielding the hex color to draw an entity in
+export function createDxfColorResolver(text, parsed, colors, defaultColor) {
+    const trueColors = extractTrueColors(text);
+    const layerTables = parsed.tables?.layers ?? {};
+    return (entity) => {
+        // An own 24 bit color is a deliberate choice and is used verbatim, black included
+        const trueColor = trueColors[entity.handle];
+        if (trueColor) {
+            return rgbToHex(trueColor);
+        }
+        let colorNumber = entity.colorNumber;
+        // BYBLOCK should take the color of the placing INSERT, which denormalise() drops, so it falls back to the layer as well
+        if (colorNumber === undefined || colorNumber === COLOR_BYLAYER || colorNumber === COLOR_BYBLOCK) {
+            colorNumber = layerTables[entity.layer]?.colorNumber;
+        }
+        const rgb = colors[colorNumber] ?? colors[0];
+        return isDefaultAciColor(rgb) ? defaultColor : rgbToHex(rgb);
+    };
+}
+
 export function explodeDxf(text) {
     const tuples = text.replace(/\s+$/, '').split(/\r\n|\r|\n/g).flatMap((_, i, a) => i % 2 ? [] : [a.slice(i, i + 2).map(x => x.trim())]);
     let maxHandle = 100; // Value in QGIS

--- a/utils/FileImportUtils.js
+++ b/utils/FileImportUtils.js
@@ -11,11 +11,11 @@ import Proj4js from 'proj4';
 
 import ConfigUtils from './ConfigUtils';
 import CoordinatesUtils from './CoordinatesUtils';
-import {decodeDxf, unescapeDxfUnicode} from './DxfUtils';
+import {createDxfColorResolver, decodeDxf, unescapeDxfUnicode} from './DxfUtils';
 import LocaleUtils from './LocaleUtils';
 import VectorLayerUtils from './VectorLayerUtils';
 
-// Stroke color for DXF entities without an own color
+// Stroke color for DXF entities left at the ACI default color
 const DXF_DEFAULT_COLOR = '#1565C0';
 
 const FileImportUtils = {
@@ -105,12 +105,17 @@ const FileImportUtils = {
         }
     },
     // DXF carries no CRS, the coordinates are taken to be in the passed crs. Entities without a
-    // polyline representation (i.e. TEXT/MTEXT) are dropped, splines are approximated.
+    // polyline representation (i.e. TEXT/MTEXT and HATCH) are dropped, splines are approximated.
     addDXFLayer: async(filename, data, crs, addLayerFeatures) => {
-        const {Helper} = await import('dxf');
+        const {colors, Helper} = await import('dxf');
         let polylines = [];
+        let entities = [];
+        let resolveColor = null;
         try {
-            polylines = new Helper(data).toPolylines().polylines;
+            const helper = new Helper(data);
+            polylines = helper.toPolylines().polylines;
+            entities = helper.denormalised;
+            resolveColor = createDxfColorResolver(data, helper.parsed, colors, DXF_DEFAULT_COLOR);
         } catch (e) {
             /* eslint-disable-next-line */
             console.warn(e);
@@ -118,20 +123,23 @@ const FileImportUtils = {
             alert(LocaleUtils.tr("importlayer.dxfparsefailed"));
             return;
         }
-        const features = polylines.filter(polyline => (polyline.vertices || []).length >= 2).map((polyline, idx) => {
-            // Color 0 means "by layer" in DXF and surfaces as black, which is invisible on dark backgrounds
-            const rgb = polyline.rgb || [0, 0, 0];
-            const color = rgb.every(v => v === 0) ? DXF_DEFAULT_COLOR : ("#" + rgb.map(v => v.toString(16).padStart(2, "0")).join(""));
+        // toPolylines() maps the denormalised entities one to one
+        const entitiesAligned = entities.length === polylines.length;
+        const features = polylines.map((polyline, idx) => ({
+            entity: entitiesAligned ? entities[idx] : null,
+            polyline: polyline
+        })).filter(entry => (entry.polyline.vertices || []).length >= 2).map((entry, idx) => {
+            const color = entry.entity ? resolveColor(entry.entity) : DXF_DEFAULT_COLOR;
             return {
                 type: "Feature",
                 id: idx,
                 crs: crs,
                 geometry: {
                     type: "LineString",
-                    coordinates: polyline.vertices.map(vertex => [vertex[0], vertex[1]])
+                    coordinates: entry.polyline.vertices.map(vertex => [vertex[0], vertex[1]])
                 },
                 properties: {
-                    layer: unescapeDxfUnicode(polyline.layer?.name ?? "")
+                    layer: unescapeDxfUnicode(entry.polyline.layer?.name ?? "")
                 },
                 styleName: "default",
                 styleOptions: {


### PR DESCRIPTION
Apparently QGIS Server's dxf export writes all colors to group code 420 which the `dxf` package does not handle at all, that's why every entities color falls back to red, ACI color 1 in the LAYER table..

This PR adds `createDxfColorResolver` which reads the color off the file itself and applies the dxf coloring according to "its own 24 bit color -> its own color number -> BYLAYER/BYBLOCK layer table entry". Entities with the ACI default fall back to the `DXF_DEFAULT_COLOR` (blue).

On a side note: I added a `rgbToHex` method, I think there are at least two other places in the codebase (`MiscUtils.js` and `VectorLayerUtils.js`) using some kind of RGB to Hex transformation. We could consolidate this into an reusable function.

On a second side note: HATCHES, TEXT and MTEXT are still dropped, I'll work on those next.

On a third side note: I never wanted to know all this DXF stuff.