### PR TITLE
Print: allow a list of prefixes for layoutHidePrefix

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -1031,7 +1031,7 @@ Uses the print layouts defined in the QGIS project.
 | gridInitiallyEnabled | `bool` | Whether the grid is enabled by default. | `false` |
 | hideAutopopulatedFields | `bool` | Whether to hide form fields which contain autopopulated values (i.e. search result label). | `undefined` |
 | inlinePrintOutput | `bool` | Whether to display the print output in an inline dialog instead triggering a download. | `false` |
-| layoutHidePrefix | `string` | Hide layouts which begin with this prefix. | `undefined` |
+| layoutHidePrefix | `{string, [string]}` | Hide layouts which begin with this prefix, or with any of the prefixes in the specified list. | `undefined` |
 | layoutSortOrder | `string` | Layout sort order, asc or desc. | `'asc'` |
 | movePrintSeries | `bool` | Whether to allow moving the extent while selecting the print series. | `false` |
 | omitLayoutPathsFromTitle | `bool` | Whether to cut off any layout path prefixes (i.e. as in `subdir/Layout Name`) from the layout titles displayed in selection combo. | `undefined` |

--- a/plugins/Print.jsx
+++ b/plugins/Print.jsx
@@ -71,8 +71,8 @@ class Print extends React.Component {
         /** Whether to display the print output in an inline dialog instead triggering a download. */
         inlinePrintOutput: PropTypes.bool,
         layers: PropTypes.array,
-        /** Hide layouts which begin with this prefix. */
-        layoutHidePrefix: PropTypes.string,
+        /** Hide layouts which begin with this prefix, or with any of the prefixes in the specified list. */
+        layoutHidePrefix: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
         /** Layout sort order, asc or desc. */
         layoutSortOrder: PropTypes.string,
         map: PropTypes.object,
@@ -146,8 +146,10 @@ class Print extends React.Component {
         if (prevProps.theme !== this.props.theme) {
             if (this.props.theme && !isEmpty(this.props.theme.print)) {
                 const sortDir = this.props.layoutSortOrder === "desc" ? -1 : 1;
+                const hidePrefixes = [this.props.layoutHidePrefix ?? []].flat();
                 const layouts = this.props.theme.print.filter(l => {
-                    return l.map && !l.name.split('/').pop().startsWith(this.props.layoutHidePrefix);
+                    const name = l.name.split('/').pop();
+                    return l.map && !hidePrefixes.some(prefix => name.startsWith(prefix));
                 }).sort((a, b) => {
                     return sortDir * a.name.split('/').pop().localeCompare(b.name.split('/').pop(), undefined, {numeric: true});
                 });


### PR DESCRIPTION
This PR adds the possibility to add a list of prefixes to `layoutHidePrefix`. Passing a single string works as before, so existing configuration does not break.